### PR TITLE
fix: Skip Xvfb on macOS and Windows

### DIFF
--- a/src/vice/process.ts
+++ b/src/vice/process.ts
@@ -28,6 +28,7 @@ export function delay(ms: number): Promise<void> {
 }
 
 function hasGraphicalSession(): boolean {
+  if (process.platform === "darwin" || process.platform === "win32") return true;
   return configuredDisplay() !== undefined || configuredWaylandDisplay() !== undefined;
 }
 

--- a/src/viceRunner.ts
+++ b/src/viceRunner.ts
@@ -109,6 +109,7 @@ function which(binary: string): string | null {
 }
 
 function shouldUseXvfb(): boolean {
+  if (process.platform === "darwin" || process.platform === "win32") return false;
   if (process.env.FORCE_XVFB === "1") return true;
   const ciValue = (process.env.CI || "").toLowerCase();
   return ciValue === "true" || ciValue === "1" || ciValue === "yes";


### PR DESCRIPTION
## Summary
  - On macOS and Windows, VICE renders natively without X11, so Xvfb is never needed
  - hasGraphicalSession() only checked for DISPLAY/WAYLAND_DISPLAY env vars (Linux-specific), returning false on macOS and causing spawn Xvfb ENOENT
  - Added process.platform early-return in both src/vice/process.ts and src/viceRunner.ts to skip Xvfb on non-Linux platforms

  ## Test plan
  - [x] Verified node ./dist/index.js starts cleanly on macOS (was crashing with ENOENT)
  - [ ] Confirm Linux CI still uses Xvfb when appropriate (CI=true or no graphical session)