### PR TITLE
fix: Flatten discriminated union schemas for Claude API compatibility

### DIFF
--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -137,13 +137,54 @@ export function discriminatedUnionSchema(options: DiscriminatedUnionSchemaOption
     throw new Error("Discriminated union schemas require at least one variant.");
   }
 
+  // Flatten the discriminated union into a single object schema.
+  // Claude's API does not support oneOf/allOf/anyOf at the top level,
+  // so we merge all variant properties and use an enum for the discriminator.
+  const opValues: string[] = [];
+  const mergedProperties: Record<string, JsonSchema> = {};
+  const opDescriptions: string[] = [];
+
+  for (const variant of variants) {
+    const variantProps = variant.properties ?? {};
+    const discProp = variantProps[discriminator];
+    const opValue = discProp?.const as string | undefined;
+
+    if (opValue) {
+      opValues.push(opValue);
+      const variantDesc = variant.description ?? discProp?.description ?? "";
+      if (variantDesc) {
+        opDescriptions.push(`${opValue}: ${variantDesc}`);
+      }
+    }
+
+    for (const [key, propSchema] of Object.entries(variantProps)) {
+      if (key === discriminator) continue;
+      if (!mergedProperties[key]) {
+        mergedProperties[key] = propSchema;
+      }
+    }
+  }
+
+  const opPropertySchema: JsonSchema = opValues.length > 0
+    ? { type: "string", enum: opValues, description: `Selects the operation.` }
+    : { type: "string", description: `Selects the operation.` };
+
+  const fullDescription = description
+    ? (opDescriptions.length > 0
+        ? `${description}\n\nOperations:\n${opDescriptions.map((d) => `- ${d}`).join("\n")}`
+        : description)
+    : (opDescriptions.length > 0
+        ? `Operations:\n${opDescriptions.map((d) => `- ${d}`).join("\n")}`
+        : undefined);
+
   const schema: JsonSchema = {
     type: "object",
-    ...(description ? { description } : {}),
-    oneOf: [...variants],
-    discriminator: {
-      propertyName: discriminator,
+    ...(fullDescription ? { description: fullDescription } : {}),
+    properties: {
+      [discriminator]: opPropertySchema,
+      ...mergedProperties,
     },
+    required: [discriminator],
   };
 
   return schema;

--- a/test/toolsTypes.test.mjs
+++ b/test/toolsTypes.test.mjs
@@ -70,8 +70,9 @@ test("operationSchema supports explicit op descriptions and extra properties", (
   assert.equal(schema.additionalProperties, true);
 });
 
-test("discriminatedUnionSchema composes variant schemas", () => {
+test("discriminatedUnionSchema flattens variants into a single object schema", () => {
   const readSchema = operationSchema("read", {
+    description: "Read memory",
     properties: {
       address: { type: "integer" },
       length: { type: "integer" },
@@ -80,6 +81,7 @@ test("discriminatedUnionSchema composes variant schemas", () => {
   });
 
   const writeSchema = operationSchema("write", {
+    description: "Write memory",
     properties: {
       address: { type: "integer" },
       data: { type: "string" },
@@ -92,12 +94,19 @@ test("discriminatedUnionSchema composes variant schemas", () => {
     variants: [readSchema, writeSchema],
   });
 
-  assert.deepEqual(union, {
-    description: "Memory operations",
-    oneOf: [readSchema, writeSchema],
-    discriminator: { propertyName: OPERATION_DISCRIMINATOR },
-    type: "object",
-  });
+  assert.equal(union.type, "object");
+  assert.ok(union.description.includes("Memory operations"));
+  assert.ok(union.description.includes("read:"));
+  assert.ok(union.description.includes("write:"));
+  assert.deepEqual(union.properties[OPERATION_DISCRIMINATOR].enum, ["read", "write"]);
+  assert.deepEqual(union.required, [OPERATION_DISCRIMINATOR]);
+  // All variant properties merged
+  assert.ok(union.properties.address);
+  assert.ok(union.properties.length);
+  assert.ok(union.properties.data);
+  // No oneOf at top level
+  assert.equal(union.oneOf, undefined);
+  assert.equal(union.discriminator, undefined);
 });
 
 test("discriminatedUnionSchema requires at least one variant", () => {
@@ -113,7 +122,8 @@ test("discriminatedUnionSchema supports custom discriminator names", () => {
     variants: [{ type: "object", properties: { mode: { const: "x" } } }],
   });
 
-  assert.equal(union.discriminator.propertyName, "mode");
+  assert.deepEqual(union.properties.mode.enum, ["x"]);
+  assert.deepEqual(union.required, ["mode"]);
 });
 
 test("createOperationDispatcher routes to matching handlers", async () => {


### PR DESCRIPTION
## Summary
- Claude's tool-use API does not support `oneOf`/`anyOf`/`allOf` at the top level of input schemas
- Flattens `discriminatedUnionSchema` to merge all variant properties into a single object schema with an enum-constrained discriminator
- Allows Claude to correctly parse and call grouped tools like `c64_program`, `c64_memory`, `c64_sound`, etc.

## Test plan
- [x] Updated `toolsTypes.test.mjs` to verify flattened output (no `oneOf`, enum on discriminator, all properties merged)
- [ ] Verify grouped tool calls work end-to-end from Claude Code