### PR TITLE
fix: Improve Claude support by flattening discriminated union schemas and improving hex data handling

### DIFF
--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -8,7 +8,7 @@ import {
   type ToolRunResult,
 } from "./types.js";
 import { booleanSchema, numberSchema, objectSchema, optionalSchema, stringSchema } from "./schema.js";
-import { textResult } from "./responses.js";
+import { jsonResult, textResult } from "./responses.js";
 import {
   ToolError,
   ToolExecutionError,
@@ -217,13 +217,15 @@ async function executeReadMemory(rawArgs: unknown, ctx: ToolExecutionContext): P
     const resolvedAddress = resolveAddressLabel(detailRecord, parsed.address);
     const resolvedLength = resolveLength(detailRecord) ?? parsed.length;
 
-    return textResult(`Read ${resolvedLength} bytes starting at ${resolvedAddress}.`, {
-      success: true,
-      address: resolvedAddress,
-      length: resolvedLength,
-      hexData: result.data ?? null,
-      details: detailRecord,
-    });
+    return jsonResult(
+      {
+        success: true,
+        address: resolvedAddress,
+        length: resolvedLength,
+        hexData: result.data ?? null,
+        details: detailRecord,
+      },
+    );
   } catch (error) {
     if (error instanceof ToolError) {
       return toolErrorResult(error);

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -137,13 +137,54 @@ export function discriminatedUnionSchema(options: DiscriminatedUnionSchemaOption
     throw new Error("Discriminated union schemas require at least one variant.");
   }
 
+  // Flatten the discriminated union into a single object schema.
+  // Claude's API does not support oneOf/allOf/anyOf at the top level,
+  // so we merge all variant properties and use an enum for the discriminator.
+  const opValues: string[] = [];
+  const mergedProperties: Record<string, JsonSchema> = {};
+  const opDescriptions: string[] = [];
+
+  for (const variant of variants) {
+    const variantProps = variant.properties ?? {};
+    const discProp = variantProps[discriminator];
+    const opValue = discProp?.const as string | undefined;
+
+    if (opValue) {
+      opValues.push(opValue);
+      const variantDesc = variant.description ?? discProp?.description ?? "";
+      if (variantDesc) {
+        opDescriptions.push(`${opValue}: ${variantDesc}`);
+      }
+    }
+
+    for (const [key, propSchema] of Object.entries(variantProps)) {
+      if (key === discriminator) continue;
+      if (!mergedProperties[key]) {
+        mergedProperties[key] = propSchema;
+      }
+    }
+  }
+
+  const opPropertySchema: JsonSchema = opValues.length > 0
+    ? { type: "string", enum: opValues, description: `Selects the operation.` }
+    : { type: "string", description: `Selects the operation.` };
+
+  const fullDescription = description
+    ? (opDescriptions.length > 0
+        ? `${description}\n\nOperations:\n${opDescriptions.map((d) => `- ${d}`).join("\n")}`
+        : description)
+    : (opDescriptions.length > 0
+        ? `Operations:\n${opDescriptions.map((d) => `- ${d}`).join("\n")}`
+        : undefined);
+
   const schema: JsonSchema = {
     type: "object",
-    ...(description ? { description } : {}),
-    oneOf: [...variants],
-    discriminator: {
-      propertyName: discriminator,
+    ...(fullDescription ? { description: fullDescription } : {}),
+    properties: {
+      [discriminator]: opPropertySchema,
+      ...mergedProperties,
     },
+    required: [discriminator],
   };
 
   return schema;

--- a/test/toolsTypes.test.mjs
+++ b/test/toolsTypes.test.mjs
@@ -70,8 +70,9 @@ test("operationSchema supports explicit op descriptions and extra properties", (
   assert.equal(schema.additionalProperties, true);
 });
 
-test("discriminatedUnionSchema composes variant schemas", () => {
+test("discriminatedUnionSchema flattens variants into a single object schema", () => {
   const readSchema = operationSchema("read", {
+    description: "Read memory",
     properties: {
       address: { type: "integer" },
       length: { type: "integer" },
@@ -80,6 +81,7 @@ test("discriminatedUnionSchema composes variant schemas", () => {
   });
 
   const writeSchema = operationSchema("write", {
+    description: "Write memory",
     properties: {
       address: { type: "integer" },
       data: { type: "string" },
@@ -92,12 +94,19 @@ test("discriminatedUnionSchema composes variant schemas", () => {
     variants: [readSchema, writeSchema],
   });
 
-  assert.deepEqual(union, {
-    description: "Memory operations",
-    oneOf: [readSchema, writeSchema],
-    discriminator: { propertyName: OPERATION_DISCRIMINATOR },
-    type: "object",
-  });
+  assert.equal(union.type, "object");
+  assert.ok(union.description.includes("Memory operations"));
+  assert.ok(union.description.includes("read:"));
+  assert.ok(union.description.includes("write:"));
+  assert.deepEqual(union.properties[OPERATION_DISCRIMINATOR].enum, ["read", "write"]);
+  assert.deepEqual(union.required, [OPERATION_DISCRIMINATOR]);
+  // All variant properties merged
+  assert.ok(union.properties.address);
+  assert.ok(union.properties.length);
+  assert.ok(union.properties.data);
+  // No oneOf at top level
+  assert.equal(union.oneOf, undefined);
+  assert.equal(union.discriminator, undefined);
 });
 
 test("discriminatedUnionSchema requires at least one variant", () => {
@@ -113,7 +122,8 @@ test("discriminatedUnionSchema supports custom discriminator names", () => {
     variants: [{ type: "object", properties: { mode: { const: "x" } } }],
   });
 
-  assert.equal(union.discriminator.propertyName, "mode");
+  assert.deepEqual(union.properties.mode.enum, ["x"]);
+  assert.deepEqual(union.required, ["mode"]);
 });
 
 test("createOperationDispatcher routes to matching handlers", async () => {


### PR DESCRIPTION
## Summary
- `textResult` buries the hex payload in metadata, which Claude's tool-use API cannot access
- Switching to `jsonResult` puts address, length, and hexData fields directly in the content body
- Without this fix, Claude reports that memory read data is not in the response

## Test plan
- [ ] Read memory via Claude Code MCP and verify hex data is visible in the response