### PR TITLE
fix: harden C64 Bridge against 35 review findings (HARD01-001..035)

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,7 +809,7 @@ Cross-platform PETSCII typing plus native Ultimate keyboard and joystick events.
 
 | Operation | Description | Required Inputs | Optional Inputs | C64U | U2 | VICE |
 | --- | --- | --- | --- | --- | --- | --- |
-| `joystick` | Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers. | `port`, `controls`, `action` | `durationMs=80` | ✅ |  | ✅ |
+| `joystick` | Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set. | `port`, `controls`, `action` | `durationMs=80` | ✅ |  | ✅ |
 | `key` | Tap a single key or hold it for a duration. | `key` | `durationMs=0`, `count=1` | ✅ | ✅ | ✅ |
 | `keyboard` | Send physical C64 keyboard matrix events through machine:input (a C64U firmware version that provides it, or U64 3.15+). | `inputs`, `transition` | — | ✅ |  |  |
 | `release_all` | Release every key and joystick control injected through machine:input (a C64U firmware version that provides it, or U64 3.15+). | — | — | ✅ |  |  |
@@ -839,9 +839,9 @@ Grouped entry point for Commodore and Epson printing helpers.
 
 | Operation | Description | Required Inputs | Optional Inputs | C64U | U2 | VICE |
 | --- | --- | --- | --- | --- | --- | --- |
-| `define_chars` | Define custom printer characters (Commodore DLL mode). | `firstChar`, `chars` | `secondaryAddress` | ✅ |  |  |
-| `print_bitmap` | Print a bitmap row via Commodore (BIM) or Epson ESC/P workflows. | `printer="commodore"`, `columns` | `repeats`, `useSubRepeat`, `secondaryAddress`, `ensureMsb=true`, `mode`, `density`, `timesPerLine` | ✅ |  |  |
-| `print_text` | Generate BASIC that prints text to device 4. | `text` | `target="commodore"`, `secondaryAddress`, `formFeed=false` | ✅ |  |  |
+| `define_chars` | Define custom printer characters (Commodore DLL mode). | `firstChar`, `chars` | `secondaryAddress` | ✅ | ✅ |  |
+| `print_bitmap` | Print a bitmap row via Commodore (BIM) or Epson ESC/P workflows. | `printer="commodore"`, `columns` | `repeats`, `useSubRepeat`, `secondaryAddress`, `ensureMsb=true`, `mode`, `density`, `timesPerLine` | ✅ | ✅ |  |
+| `print_text` | Generate BASIC that prints text to device 4. | `text` | `target="commodore"`, `secondaryAddress`, `formFeed=false` | ✅ | ✅ |  |
 
 #### c64_program
 

--- a/doc/reviews/hardening/01-fable/prompt-handover.md
+++ b/doc/reviews/hardening/01-fable/prompt-handover.md
@@ -1,0 +1,125 @@
+# Hardening 01 — handover: finish the poll-truthfulness fix, then adversarially review and land the branch
+
+Repository: `/home/chris/dev/c64/c64bridge`
+Branch: `fix/hardening` (already pushed once as PR #143, previously brought to a green/merge-ready state)
+This file: `doc/reviews/hardening/01-fable/prompt-handover.md`
+
+This is a handover from a session that (1) got PR #143 to a fully green, merge-ready state addressing five Kilo Code review comments and raising patch coverage to ~96%, then (2) at the user's request, ran **real physical hardware tests** (C64U, Ultimate 64, Ultimate II+L) against the live MCP server, and (3) found a genuine, reproducible false-success bug during that testing. A fix is in progress but not finished, verified, or committed. You are picking this up cold — there is no prior conversation for you to recall.
+
+Do not consider this session's work "done" until Part 3's exit criteria are met. Do not claim completion while any part below remains unresolved.
+
+## Part 0 — Orient yourself first
+
+1. Read `AGENTS.md` in full.
+2. Read `doc/reviews/hardening/01-fable/review.md` and `doc/reviews/hardening/01-fable/prompt.md` for the original 35-finding hardening context (HARD01-001..035) — this branch already implements all of them, plus five follow-up fixes from a Kilo Code automated review round, plus coverage work. That prior work is committed (`git log --oneline` back to `cfb7e4a`). Nothing in that history needs redoing.
+3. Run `git status` and `git diff --stat` to see the exact uncommitted state you're inheriting (summarized precisely in Part 1 below — but verify it yourself, the working tree may have drifted).
+4. Check `gh pr view 143 --repo chrisgleissner/c64bridge` and `gh pr checks 143 --repo chrisgleissner/c64bridge` for the PR's current state. As of this handover, PR #143 is green and all prior review threads are resolved — the uncommitted work described below is a **new, additional** round on top of that.
+
+## Background: what real-hardware testing found
+
+The session tested the live MCP server against three genuinely separate physical devices (confirmed via distinct firmware `unique_id`s):
+
+- **C64U** — hostname `c64u`, product "C64 Ultimate", firmware 1.2.0.
+- **Ultimate 64 Elite** — hostname `u64`, firmware 3.15. Fully independent hardware (its own board), but uses the same `c64u` backend profile/config key as C64U (same REST API family). The c64bridge config format has exactly one `c64u` slot, and the running server caches whichever host was resolved into it the first time that backend is constructed in a process — editing `.c64bridge.json` and re-selecting the backend does **not** retarget an already-constructed facade. To test C64U and U64 as genuinely separate live connections, the session registered a second temporary MCP server entry, `c64bridge-u64`, in `.mcp.json`, pointed at a separate config file (`C64BRIDGE_CONFIG` env var) with `c64u.host = "u64"`. That second server entry is a legitimate, intentional part of the current uncommitted `.mcp.json` diff — keep it (or ask the user before removing it) rather than reverting it as accidental drift.
+- **Ultimate II+L (U2)** — hostname `u2`, firmware 3.15. Physically a cartridge plugged into the back of the C64U unit — separately networked (own IP), but shares the same underlying simulated C64 bus/CPU/screen as the C64U it's plugged into. **Never drive `c64u` and `u2` operations concurrently** — they are electrically the same target machine. U64 is fully independent and safe to run alongside either.
+
+Targeted verification (firmware `errors[]` truthfulness, drive-list shape, real ASM execution, `power_cycle` honesty) passed cleanly on **C64U and U64**. On **U2**, `upload_run_basic` / `upload_run_asm` reported `success: true, verified: true` while the program **never actually executed** — confirmed independently by bypassing the MCP client entirely and sending raw HTTP `POST /v1/runners:run_prg` requests directly to the device in both `application/octet-stream` and `multipart/form-data` encodings (matching the OpenAPI spec exactly). The U2 firmware returns `200 {"errors": []}` but memory at `$0801` never changes and the screen never advances past the boot banner. This was cross-checked against the *same* physical machine via the C64U side (which genuinely does execute, visible through the shared screen) — so it is a real gap in the U2 cartridge's own firmware implementation of the upload-and-run REST feature, **not** a client-side bug. That part needs no further code change; it's a hardware/firmware limitation to document, not fix.
+
+**What is a fixable bug**, independent of the U2 firmware issue: `pollBasicOutcome()` / `pollAsmOutcome()` in `src/tools/pollValidator.ts` were blindly reporting success whenever the literal text "RUN" or "ERROR" never appeared on screen within the poll window. Since `upload_run_basic` / `upload_run_asm` execute via the native REST `run_prg` endpoint (or a typed `SYS<entry>` command for ASM) rather than a user visibly typing `RUN`, this fallback was structurally unable to provide a real signal — it happened to look correct on C64U/U64 only because execution there also happens to produce visible screen text (a KERNAL LOAD/RUN echo) for unrelated reasons. On U2, where nothing executes at all, the same fallback silently laundered a real failure into a false `verified: true`. This is exactly the class of bug the original 35 HARD01 findings targeted, just not one of them by number — a natural HARD01-036 in spirit, though nothing in code should assume that ID is registered anywhere; use it only as a descriptive tag if useful (as already done in the new tests, see below).
+
+## Part 1 — Finish the in-progress fix (do this first)
+
+### 1a. Fix already applied to `src/tools/pollValidator.ts` — verify, don't redo
+
+- `pollBasicOutcome`: previously always fell through to `return { status: "ok", type: "BASIC" }` after the poll window if no BASIC error text was ever seen, regardless of whether `runDetected` was ever set. Now, if `runDetected` is still `false` after the full poll window, it returns `{ status: "error", type: "BASIC", message: "No execution activity detected: the firmware reported success, but the program does not appear to have run." }` instead.
+- `pollAsmOutcome`: previously returned `{ status: "ok", type: "ASM" }` immediately if `runDetected` was never set, **skipping** the hardware liveness check (screen-RAM CRC comparison) entirely. That early return is removed — execution now always falls through to the liveness check regardless of whether "RUN"/"ERROR" text was ever seen. Only the two log lines and a comment changed around this; the liveness-check logic itself (already correct, from the original HARD01-019/020 work) is untouched.
+
+Confirm this is still exactly what's in the working tree (`git diff src/tools/pollValidator.ts`) before proceeding — do not re-derive it from scratch, but do sanity-check it against the description above.
+
+### 1b. Test updates already applied — verify, don't redo
+
+`test/pollValidator.test.mjs`:
+- Two tests that previously *encoded the bug as correct behavior* — `"pollForProgramOutcome BASIC returns ok if RUN not detected"` and `"pollForProgramOutcome ASM returns ok if RUN not detected"` (both used a mock whose `readScreen()` always returns `"READY.\n"` forever, and asserted `status: "ok"`) — were renamed and fixed to assert the corrected behavior: `"HARD01-036 pollForProgramOutcome BASIC reports an error instead of blind success when RUN is never detected"` (asserts `status: "error"`, message matches `/does not appear to have run/i`) and `"HARD01-036 pollForProgramOutcome ASM reports crashed instead of blind success when RUN is never detected"` (asserts `status: "crashed"`, `reason: "no program-visible screen progression within window"`).
+- A new positive-case test was added, `"HARD01-036 pollForProgramOutcome ASM still detects real liveness even when RUN text never appears"`, confirming the fix doesn't regress the case where RUN/ERROR text never shows but screen RAM genuinely changes (must still report `ok`).
+
+`test/programRunnersModule.test.mjs`:
+- `"upload_run_basic verify true annotates metadata"`: mock's `readScreen()` previously always returned `"READY.\n"`; now returns `"READY.\n"` on the first call (the tool's own pre-poll screen check) and `"RUN\n"` thereafter (matching how a real backend's LOAD/RUN echo actually behaves), so the poll genuinely observes execution instead of relying on the old blind-success fallback.
+- `"upload_run_basic verify tolerates repeated screen read failures"`: mock's `readScreen()` previously threw on *every* call, and the test asserted success. That was itself an instance of the bug (permanent failure ≠ "tolerated" success). Now the mock throws only on the first 3 calls, then returns `"RUN\n"` — genuinely testing transient-failure tolerance, not permanent-failure-as-success.
+- `"upload_run_asm returns structured content on success"`: the mock previously had no `readScreen`/`readMemoryRaw` at all (relying on the old shortcut to skip verification entirely, even though `executeUploadRunAsm` calls `pollForProgramOutcome` unconditionally regardless of the `verify` flag). Now includes a minimal `readScreen` (`"RUN\n"`) and `readMemoryRaw` (returns a changing byte pattern) so the now-mandatory liveness check has something real to observe.
+- `"upload_run_asm verify treats repeated screen read failures as instant execution"` — this test's *name* literally described the bug as a feature. Renamed to `"upload_run_asm verify tolerates transient screen read failures and still verifies via liveness"` and its mock changed from permanent to transient (3) failures followed by success, mirroring the BASIC fix above.
+
+Confirm `test/pollValidator.test.mjs` and `test/programRunnersModule.test.mjs` diffs match this description; run `timeout 120 node scripts/run-tests.mjs test/pollValidator.test.mjs test/programRunnersModule.test.mjs test/groupedToolsShims.test.mjs` and confirm all green (96/96 in the second file, 22/22 in the first, as of last check).
+
+### 1c. Leftover test artifacts already cleaned up — verify, don't redo
+
+The hardware-testing session had left two untracked scratch files in the repo root — `.c64bridge.json` (containing `{"u2": {"host": "u2", "port": 80}}`) and `.c64bridge.u64.json`. These were interfering with `test/device.test.mjs`'s `"falls back to vice or c64u when no config"` test via `config.ts`'s "legacy package-adjacent config" fallback candidate (`dirname(import.meta.url of config.ts)/../.c64bridge.json`), which resolves relative to the *source file location*, not `process.cwd()` — so it bypasses that test's directory-isolation helper (`withConfigScenario`) entirely. Both files have already been deleted. Run `git status --porcelain` and confirm neither file is present; if either has reappeared (e.g. from a stray tool run), delete it again before running the full suite — it will cause spurious, hard-to-diagnose failures in `device.test.mjs` and possibly elsewhere.
+
+### 1d. NOT yet fixed — this is the actual remaining work
+
+`scripts/mockC64Server.mjs` was modified to make the C64U mock server's simulated `injectKeyboardQueue` path (used by `upload_run_asm`'s typed `SYS<entry>` trigger) produce *some* observable screen-RAM change, since the mock runs no real 6502 code and the now-mandatory liveness check in `pollAsmOutcome` needs something to observe. The current approach: `simulateKeyboardDrain()` (which already existed, to drain the KERNAL NDX counter) now also detects when the queued/typed text matches `/SYS\s*\d+/i` and, if so, starts a `setInterval` "heartbeat" that increments `state.memory[0x0400]` every 20ms for up to 50 ticks (~1 second), simulating an alive, still-running program.
+
+**This introduced a real regression**: the heartbeat is a background timer with no cleanup tied to test boundaries. Because `test/c64Client.test.mjs` shares one mock server/client instance across many sequential `t.test()` subtests (no `resetState()`/reset call between them), an *earlier* subtest in that file — `"HARD01-018 uploadAndRunAsm loads the assembled PRG..."` (around line 456) or `"HARD01-018 uploadAndRunAsm keeps a non-$0801 origin intact..."` (around line 475), both of which trigger a `SYS...` pattern — leaves a heartbeat ticking for up to a second. A *later*, unrelated subtest a few lines down, `"readMemory returns hex string with prefix"` (around line 506), which expects to read back the exact bytes (`$AA55`) written by the immediately-preceding `"writeMemory writes bytes to mock memory"` subtest, instead observes `$AB55` — the first byte has been incremented by exactly 1 by the still-running heartbeat from the earlier subtest. Confirmed via direct code inspection; not yet re-confirmed by test run after the last edit (the fix attempt was mid-flight when this handover was written — you may find it still fails, or fails intermittently depending on timing).
+
+**Fix this properly before doing anything else.** Suggested directions, roughly in order of robustness (pick one, don't feel obligated to preserve the current heartbeat mechanism if a cleaner design fits better):
+
+1. **Time-computed overlay instead of a live timer (recommended).** Instead of a `setInterval` that mutates `state.memory` in the background, record `state.heartbeat = { startedAt: Date.now(), durationMs, baseValue }` when a `SYS` command is detected, and have the `machine:readmem` handler (or wherever `$0400` reads are served) compute a *synthetic* byte value on read — e.g. `baseValue + Math.floor((Date.now() - startedAt) / 20) & 0xff` — only while `Date.now() - startedAt < durationMs`, otherwise return the real stored byte. This eliminates all background timers and the cross-test leakage entirely: nothing mutates `state.memory` asynchronously, so an unrelated `writeMemory`/`readMemory` pair immediately after a `SYS`-triggering subtest is unaffected (the overlay only applies to reads of that specific address, and only while a window is "active" for a specific triggering event — consider whether the overlay should apply narrowly enough that a real write to `$0400` by a later subtest correctly overrides/disables it, e.g. by clearing `state.heartbeat` on any explicit write to that address).
+2. **Track and clear timers explicitly.** Keep the `setInterval` approach, but store the active heartbeat handle in `state` (e.g. `state.activeHeartbeat`), clear any previous one before starting a new one, and clear it in `resetState()`. This only fully solves leakage across resets — it does **not** solve leakage between sequential subtests in the *same* file that never call reset (the actual failure mode observed), so this alone is likely insufficient without also auditing whether `t.test()` sequences in shared-client test files should call `mock.reset()` between subtests (check `test/c64Client.test.mjs`'s setup/teardown and `test/helpers/mcpTestHarness.mjs`'s `withSharedMcpClient` for whether that's feasible without breaking other assumptions).
+3. **Shrink the blast radius.** If you keep a live timer, drastically shorten its duration (a handful of ticks over ~40-60ms) so it's very unlikely to outlive the specific subtest that triggered it, while remaining long enough to intersect the poll windows used by tests that override `C64BRIDGE_POLL_MAX_MS`/`C64BRIDGE_POLL_INTERVAL_MS` (values as low as `maxMs: 50, intervalMs: 10` appear in the test suite — check the *smallest* configured poll window across all callers before picking a duration, not just the ones you happen to be looking at). This is the least robust option and only worth using if 1 and 2 both prove impractical.
+
+Whichever approach you take, the fix must satisfy **all** of:
+- `test/suites/mcpServerCallToolSuite.mjs`'s `"c64_program upload_run_asm assembles source and runs program"` test passes reliably (run it standalone at least 10 times in a loop to rule out flakiness, not just once).
+- `test/c64Client.test.mjs` passes with no cross-subtest interference (run the whole file standalone, and also as part of the full suite — the earlier failure only manifested in the full-suite/whole-file run, not a single-test run, so isolated single-test passes are not sufficient evidence).
+- No new timer/interval leaks the Node/Bun process past test completion (check for "open handle" warnings if your test runner surfaces them).
+- The underlying simulation stays scoped to the `SYS`-command pattern specifically — `injectKeyboardQueue` is also used by `src/tools/input.ts` for general `key`/`write_text` operations, and those must not trigger this heartbeat/overlay behavior.
+
+After fixing, `timeout 300 npm test` must show **0 failures** across the entire suite (as of last check before the mock-server regression, the count was 792 tests / 788 pass / 2 skip / 0 fail with the pollValidator fix alone, before the mock-server change was introduced — use that as your target, adjusting only for whatever new tests you may have added).
+
+### 1e. Full validation gate for Part 1
+
+Once the full suite is green, run the complete validation gate used earlier in this branch's history (see recent commits `ad93c5d`, `417ec89` for the pattern):
+
+```
+npx tsc -p tsconfig.json --noEmit
+npm test
+npm run test:vice:mock
+npm run build
+npm run check:package
+git diff --check
+```
+
+All must pass cleanly. `npm run build` regenerates `mcp/*.json` and `README.md` from source/schema — if those come out changed, that's expected only if you touched schemas; otherwise investigate rather than blindly committing a diff you don't understand.
+
+Also reconsider **patch coverage**: this branch has an established pattern (see commit `ad93c5d`'s message and `.mcp.json`-adjacent `codecov.yml`) of keeping patch coverage above ~94% by, among other things, moving standalone explanatory comments onto the code line they document as trailing comments (since this project's bun-based coverage tooling counts every comment/blank line in a diff hunk as an uncovered patch line). Apply the same discipline to your new diff if it introduces many multi-line comments in changed regions — it's cheap and keeps the codecov gate comfortably clear.
+
+## Part 2 — Adversarial review of the current branch
+
+Once Part 1 is fully green and validated (but not yet committed — or committed as a checkpoint if you prefer smaller commits, your call), perform a genuinely adversarial review of the **entire branch diff against `main`** (i.e. `git diff main...HEAD` plus your uncommitted changes) — not just the new pollValidator/mock-server work. This branch has already been through one automated review round (Kilo Code, five findings, all fixed) and one round of real-hardware testing (which is what surfaced the bug you just fixed) — the goal now is to find what *those* rounds missed, not to re-litigate what they already caught.
+
+Use whichever of these fits best; you have access to the same skills this session had available:
+- `/codex challenge` — adversarial mode specifically designed to try to break the code. Well-suited to this task by name; consider using it as a first pass.
+- `/review` or `/code-review` — structural pre-landing review (SQL safety, trust-boundary violations, conditional side effects, simplification opportunities).
+- Manual review, if you prefer full control or the automated tools are unavailable in your environment.
+
+Focus areas, in rough priority order:
+
+1. **The same bug class elsewhere.** The pollValidator bug was "assume success when a specific text signal never appears, without checking whether that signal was ever achievable for this code path." Grep the codebase for similar patterns — any other poller, verifier, or "wait for X then assume success" loop that has a fallback branch reachable when X structurally cannot occur for some valid code path. `src/tools/programRunners.ts`, `src/c64Client.ts`, and `src/device.ts` are the highest-yield places to look, given they're where the original HARD01-011/018/019/020/021 truthfulness fixes lived.
+2. **The mock-server fidelity gap you just fixed, generalized.** If `scripts/mockC64Server.mjs` didn't simulate keyboard-queue-triggered execution at all before your fix, ask whether other mock behaviors (in this file or `src/vice/mockServer.ts`) are similarly "accepts the request, does nothing, returns success" in ways that could mask a real truthfulness bug the same way the U2 firmware gap did. You don't need to fix speculative gaps, but flag anything concrete you find.
+3. **Standard security review**: command injection, path traversal (especially around `src/tools/meta/filesystem.ts`, `src/tools/storage.ts`, and anywhere device filesystem paths are constructed — HARD01-010's fix should already cover segment encoding, but re-verify it holds against the newest code), credential/secret handling (HARD01-024's redaction — re-verify it's applied everywhere new logging was added, if any), and any newly-introduced regex (the `SYS_COMMAND_PATTERN` you may still be touching in Part 1) for ReDoS risk given it's small and simple but worth a two-second glance.
+4. **Test-suite integrity**: any other test in the suite that, like the two `programRunnersModule.test.mjs` tests you fixed, encodes a *bug* as expected behavior rather than a genuine requirement. This is a real, demonstrated pattern in this codebase now (found twice in one session) — worth a deliberate second pass rather than assuming it was fully exhausted.
+5. **The `.mcp.json` `c64bridge-u64` addition**: confirm it doesn't leak the hardware hostname `u64` or any credentials into anything that shouldn't have it (it shouldn't — no password was configured for these devices — but verify), and that it's harmless if a reader without access to that hardware tries to use this repo (the server entry will simply fail to connect, not error out the whole MCP client setup — confirm this assumption is actually true rather than taking it on faith).
+
+## Part 3 — Fix all findings, then land the branch
+
+Fix everything Part 2 surfaces, following the same discipline as the rest of this branch: minimal, root-cause fixes; a regression test for anything that was a real bug; no speculative refactors. Re-run the full Part 1e validation gate after every batch of fixes.
+
+**Exit criteria — do not stop before all of these are true:**
+
+1. `git status` is clean except for intentional, understood changes.
+2. Full validation gate (Part 1e) passes with zero failures.
+3. Changes are committed with a clear message (follow this branch's existing commit style — see `git log --oneline` — imperative, `fix:`/`test:`-prefixed, explaining *why* not just *what*).
+4. Commits are pushed to `fix/hardening` on the `chrisgleissner/c64bridge` remote.
+5. `gh pr checks 143 --repo chrisgleissner/c64bridge` shows every check green, including `codecov/patch` and `codecov/project`.
+6. If your adversarial review or the push triggers new automated review comments (Kilo Code or otherwise) on PR #143, address every one — reply explaining the fix (or the reasoning if not applicable) and resolve the thread via the GitHub API, exactly as was done for the five Kilo Code findings earlier in this PR's history (see commit `ad93c5d` and its PR comment replies for the established pattern: reply via `gh api repos/chrisgleissner/c64bridge/pulls/143/comments/{id}/replies`, resolve via the GraphQL `resolveReviewThread` mutation).
+7. No unresolved review threads remain on PR #143.
+
+Only once all seven are true is this work complete. Report back with: a summary of what the mock-server fix ended up being, what the adversarial review found (if anything) and how it was fixed, confirmation of the exit criteria, and the final CI/PR status.

--- a/doc/reviews/hardening/01-fable/prompt.md
+++ b/doc/reviews/hardening/01-fable/prompt.md
@@ -1,0 +1,98 @@
+# Hardening 01 implementation
+
+Repository: `/home/chris/dev/c64/c64bridge`
+
+Implement every confirmed finding in [review.md](./review.md): **HARD01-001 through HARD01-035**. This is an implementation task, not a second review. The review's executive-summary/count prose is stale in places; the findings index and detailed findings are authoritative. Do not omit a finding because it is P3, Medium confidence, or shares a file with another finding.
+
+## Outcome
+
+Deliver a coherent, production-safe hardening change that eliminates the false-success, wrong-target, lifecycle, input, file-system, SID, and packaging failures described in the review. Preserve the public MCP contract except where an existing success result is demonstrably false; in those cases, return a clear failure with actionable details. Add focused automated regression tests for every finding, update generated artifacts only when the source/contract change requires it, and leave the working tree with all relevant checks passing.
+
+Do not perform state-changing operations against real Ultimate hardware. Use unit tests, mock Ultimate HTTP servers, Binary Monitor stubs, and managed VICE only where the repository's existing test setup makes that safe and deterministic. Do not expose passwords or other secrets in logs, tests, fixtures, errors, or documentation.
+
+## Start correctly
+
+1. Read `AGENTS.md` and the entire adjacent `review.md` before editing. Follow the repository's `.github/skills/*/SKILL.md` instructions for any C64 execution workflow. In particular, read `c64://vice/binary-monitor-spec`/`doc/vice/vice-binary-monitor-spec.md` before changing VICE monitor framing or commands.
+2. Inspect the existing test conventions, package scripts, generated-artifact workflow, public MCP schemas, and call sites before changing result shapes or shared facade APIs.
+3. Keep changes narrow but solve root causes. Do not paper over a failure with logging, an unchecked cast, a longer timeout, or a test-only special case.
+4. Work in logical batches, but run targeted tests after each batch and the complete relevant suite before handoff. Do not claim hardware validation unless it was actually performed with explicit authorization.
+
+## Cross-cutting implementation rules
+
+- Treat Ultimate REST responses as unsuccessful when their JSON `errors` array is non-empty, even when HTTP status is 2xx. Preserve the firmware error strings in structured details. Missing `errors` remains compatible success.
+- Pin backend/facade identity for the full lifetime of a tool invocation and any spawned work. A backend switch may affect later invocations but must never retarget an operation already underway.
+- Never silently drop input, swallow a failed state-restoration operation, or report a physical action as verified when the required state cannot be observed. Report uncertainty/failure explicitly and include recovery guidance where useful.
+- Keep monitor queues and background work cancellable and recoverable. A timeout or shutdown must release subsequent work rather than permanently wedging a backend.
+- Use package-relative paths for assets shipped with the package and process-cwd paths only for deliberately user/project-local inputs. Use `fileURLToPath`, not raw URL pathnames.
+- Validate and contain all user-influenced host filesystem paths after resolution. Never rely solely on string prefix checks that permit sibling-prefix escapes; use `path.relative`/platform-aware containment.
+- Retain backward compatibility deliberately. If a formerly `void` method must signal a timeout, propagate an explicit typed result or error through every caller rather than silently discarding it.
+
+## Required fixes and acceptance criteria
+
+### HTTP transport, configuration, platform status, and package paths
+
+- **HARD01-001:** Make `--http [port]` real, or remove the dead parser/imports and the documented option together. Prefer wiring the existing parsed CLI options to a clearly factored transport-selection path using `StreamableHTTPServerTransport`; retain stdio as the default. Test that `--http 8080` selects/listens on the HTTP path and that default invocation selects stdio. Ensure MCP server/prompt registry wiring is actually used or remove the dead path.
+- **HARD01-004:** Capability probing must not cache a transient error as `unknown`. Cache confirmed availability/unavailability as appropriate, but evict/retry uncertain results. Test failure-once then success.
+- **HARD01-005, HARD01-006, HARD01-027:** Replace divergent configuration loading with one typed, authoritative loader and pass its parsed backend sections to all consumers/facade creation. Candidate precedence must match documented behavior: `C64BRIDGE_CONFIG`, then `process.cwd()/.c64bridge.json`, then home config, then defaults; retain a package-relative legacy fallback only if necessary and document its lower precedence. Resolve home via `os.homedir()` fallback and module paths through `fileURLToPath`. A malformed/unreadable candidate must produce a prominent redacted warning that identifies the file and problem, then continue to the next candidate/defaults rather than crashing or silently disagreeing. Test layered/contradictory configs, project-cwd config under an installed-style foreign package cwd, malformed config fallback, and identical host/port/password selection by startup and facade code.
+- **HARD01-016:** Establish an invocation-scoped backend snapshot/facade lease. Platform gating, all operations in a multi-step tool flow, verification, and background work must use that pinned facade. Make switching atomic with platform publication so no request is gated with one platform and sent to another. Avoid a global lock that deadlocks streams or long-running work; a reference-counted/read lease or a façade captured in tool context is preferable. Add a deterministic concurrent mock-facade test where a slow write/verify is interleaved with `c64_select_backend` and every write/read/resume step remains on the original backend.
+- **HARD01-025:** Resolve all shipped RAG data, docs, embeddings, AGENTS/prompt assets relative to the installed package/module root, not `process.cwd()`. If an override is supported, make it explicit and test it. Do not silently return an empty index merely because a bundled path was calculated incorrectly; surface a useful diagnostic when an expected bundled index cannot load. Test initialization from a foreign cwd.
+- **HARD01-031:** `c64://platform/status` must not block on a normal 10-second live REST probe. Return cached/static/not-yet-probed capability state quickly, or use a bounded short probe that cannot poison the cache. Test a never-resolving probe and assert a prompt resource result within the short bound.
+
+### Ultimate REST, input, physical-state safety, drive shape, and logging
+
+- **HARD01-002 and HARD01-003:** Rework C64U/U64 `power_cycle` to be fail-closed. Before sending final RETURN, positively determine from the menu screen's actual selection/highlight encoding that `POWER CYCLE` is selected; visible text anywhere on screen is insufficient. Confirm firmware color-matrix semantics from repository/device contract and abort on uncertainty. On every post-menu-open failure, make a safe, best-effort, idempotent attempt to close/escape the menu and return cleanup status in failure details. Never report a selected power cycle unless verification succeeds. Test different highlighted rows, all navigation-step failures, no final RETURN on mismatch, and cleanup attempts.
+- **HARD01-009:** Do not overwrite an undrained KERNAL queue. Make keyboard queue injection return a typed completion result or throw a typed timeout/error, then update every input tool call site to report partial/non-delivery accurately. Test a permanently nonzero NDX, assert no subsequent chunk overwrite, and assert the user-visible result is failure rather than success.
+- **HARD01-010:** Encode Ultimate device filesystem paths segment-by-segment so nested slash separators remain separators while special characters in segments are encoded exactly once. Cover leading slash and spaces in an HTTP request-capture test.
+- **HARD01-011:** Centralize `ActionResponse` error-array handling in the C64U/U2 backend; apply it to every action, configuration, drive, program, file, and playback method rather than hand-patching a few call sites. Nonempty `errors` must result in `success: false` and retain useful response details. Mock 200+errors for mount, run, and config operations and assert the MCP/tool layer reports failure.
+- **HARD01-017:** If write verification paused a machine and resume fails, do not let the original write success escape as a clean success. Return/throw a failure that records write/verification outcome, `machinePaused: true`, the resume failure, and clear recovery instructions; an appropriately bounded retry is acceptable. Test return and thrown resume failures.
+- **HARD01-023:** Normalize `drivesList` at the facade boundary into one documented internal shape (at least `id`, `power`, `image`, `type`, plus any needed raw details), for both VICE and Ultimate/U2. Decode the actual Ultimate `{ errors, drives: [{ id: info }] }` response rather than leaking it. Make `drive_mount_and_verify` use that normalized contract and verify the correct image-path/power fields. Test the real firmware-shaped mock response.
+- **HARD01-024:** Redact sensitive HTTP request/response diagnostic metadata case-insensitively before it reaches stderr or diagnostics persistence. At minimum mask `X-Password` and authorization/cookie-equivalent secrets. Test that a known test secret never appears while the header key/placeholder may remain useful for diagnosis.
+- **HARD01-034:** Align printer module runtime gates with advertised U2 capability: support `c64u` and `u2` if device-4 BASIC printing is actually supported by the stated contract, otherwise remove the advertised U2 feature and explain it. The likely intended fix is explicit `supportedPlatforms: ["c64u", "u2"]` on both relevant modules. Add capability/gating coverage.
+
+### VICE monitor, emulator lifecycle, input, and config
+
+- **HARD01-012:** Add per-request Binary Monitor response deadlines that reject, remove the pending request, and reset/destroy the unhealthy socket so the serialized monitor queue always releases. Use a considered timeout policy (normal versus large display transfer if needed), clear timers on response/error/close, and avoid unhandled rejections or request-ID reuse confusion. The parser must preserve framing correctness during resynchronization; do not scan arbitrary payload bytes as a new frame unless the protocol framing permits it. A stub server that accepts but never answers must prove bounded rejection and a subsequent operation must succeed after reconnect.
+- **HARD01-013:** Ensure managed VICE and Xvfb are stopped on normal exit and SIGINT/SIGTERM/SIGHUP. Since async work cannot complete in `exit`, expose/use a synchronous best-effort kill path there; signal handlers should coordinate bounded async shutdown where viable and then exit without recursive/double cleanup. Guard already-exited children. Add tests around registered handlers/child termination and, where reliable in CI, an integration check proving no managed child survives SIGTERM.
+- **HARD01-014:** Implement VICE Binary Monitor `0xA2` Joyport Set from the in-repo spec, including correctly encoded port and active-low control mask. Route VICE joystick press/release/tap through it; do not write CIA data-port registers to simulate input. Test exact BM bytes for press/release/tap and retain C64U physical-input behavior unchanged.
+- **HARD01-015:** Construct checkpoint masks so explicitly provided operations are exactly honored; default to execute only when no load/store/execute flag was requested. Test `{store:true}` serializes `0x02` and other combinations.
+- **HARD01-026:** Make VICE reset/reboot success contingent on `waitForBasicReady`'s required readiness signals. Return structured `success:false` with readiness diagnostics when it does not reach READY; update callers/tests accordingly.
+- **HARD01-035:** Stop coercing values solely because they look numeric. Determine VICE resource type from the monitor/resource API (or add an explicit value type where the public schema supports it) and send a string payload for numeric-looking string resources such as `"1541"`. Test both resource types and batched behavior.
+
+### Program execution, BASIC generation, and validation
+
+- **HARD01-007:** Generate valid Commodore BASIC V2 printer output for strings containing quotes. Do not use doubled quotes. Split expressions and emit `CHR$(34)` (while preserving all other literal characters), maintain line-length/chunking correctness, close the printer channel on normal/error paths where feasible, and ensure the tool does not claim completed printing merely because load/run started. Add generator/tokenizer-level coverage for quoted text and a VICE-facing regression if the suite supports it.
+- **HARD01-008:** Make the PETSCII screen program actually wait for a key without immediately falling through to `READY.`. Use a valid GET loop and preserve intended termination behavior. Test generated source and, if possible, rendered-screen behavior before a key press.
+- **HARD01-018:** Make `upload_run_asm` execute assembled code on every supported backend. Establish one robust contract for entry address and PRG layout: either emit a valid BASIC SYS stub for applicable loads while keeping labels/address accounting correct, or inject/run the PRG then explicitly `SYS` the assembled entry in a backend-safe manner. Do not point VICE BASIC pointers at arbitrary non-BASIC ML. Test the published `$0801` example by observing its intended memory/screen effect and test a non-$0801 origin does not corrupt BASIC workspace. Keep symbol and verification metadata truthful.
+- **HARD01-019 and HARD01-020:** Replace the ASM liveness heuristic so it neither treats free-running VIC/CIA values as activity nor reads side-effectful CIA ICRs on hardware. Prefer program-specific expected effects/explicit verification where supplied; any fallback must restrict reads to side-effect-free addresses, mask volatile registers, and honestly describe its confidence. Test a memory stream differing only at `$D012` as non-alive/crashed and assert hardware polling never overlaps `$DC0D`/`$DD0D` (or the I/O ranges whose reads have side effects).
+- **HARD01-021:** Detect BASIC runtime errors only using actual BASIC error syntax/patterns, not arbitrary occurrences of the word `ERROR`. Test `0 ERRORS FOUND` as successful and a canonical `?SYNTAX ERROR IN 20` as failure.
+
+### Background work, artifacts, and SID playback
+
+- **HARD01-022:** On reload, persisted tasks marked `running` must never remain zombie status. Either safely re-arm them once execution context is available or mark them `interrupted`/`stopped` with a restart explanation; choose and document one deterministic policy. Test persisted reload and task listing/state.
+- **HARD01-028:** Treat resolved `{ success:false }` operation results as failed task iterations, recording `lastError` and truthful status/failure counts. Decide whether retry continues; if it does, make the continued/retry status explicit. Test both thrown and returned failures.
+- **HARD01-029:** Reject unsafe `runId` and all artifact-derived filenames before writing. Resolve the output base and candidate then prove containment with `path.relative`; reject separators, traversal, absolute paths, empty normalized names, and unsafe range components. Test `../escape`, absolute/sibling-prefix escapes, and verify no out-of-tree file is created.
+- **HARD01-030:** Replace detached `music_generate` playback with tracked, cancellable work. Pin its facade/backend at creation, expose an existing-compatible stop/cancel path (integrate with the background task registry or a dedicated playback registry), stop/cancel on shutdown and before/when backend switches according to a documented policy, and do not monopolize VICE's queue beyond individual note operations. Preserve immediate scheduling response only if it truthfully says playback is scheduled/running rather than completed. Test that switching backends cannot redirect later notes and cancellation prevents future writes.
+- **HARD01-032:** Correct every SID frequency formula to the 24-bit phase accumulator: `round(hz * 16777216 / phi2)` with existing valid 16-bit clamp. Update both production implementations and knowledge/spec text, including PAL and NTSC handling. Test A4/PAL is approximately 7493 (`$1D45`) and that note-on writes low/high bytes correctly.
+- **HARD01-033:** Retrigger the SID envelope between generated notes by writing gate-low for an appropriate bounded interval before the next gate-high/note-on. Do not leave a permanently high gate except where an explicit legato contract asks for it. Test register-write sequence includes gate clearing between successive notes.
+
+## Test and validation gate
+
+At a minimum, add/extend automated tests that demonstrate every numbered acceptance criterion above. Group them sensibly (config/path, Ultimate mock HTTP, VICE BM stub/lifecycle, program generation/validation, background/SID), but name cases with the HARD01 IDs or titles so coverage is auditable. Run:
+
+1. formatter/linter/typecheck and the repository's normal test command;
+2. focused tests for every changed subsystem;
+3. package/build and generated-contract checks when applicable;
+4. a final `git diff --check` and review of all changed public schemas/docs/skills.
+
+If an existing test harness cannot safely perform a desired managed-VICE or device-level assertion, retain a deterministic stub/unit test and report the exact unperformed HIL validation as a limitation. Do not weaken a requirement merely because production hardware is unavailable.
+
+## Documentation and handoff
+
+Update docs, generated metadata, schemas, and `.github/skills` only where behavior, supported platform, failure/recovery behavior, or invocation semantics changed. In particular, keep `AGENTS.md`, README/developer docs, platform-status capabilities, and MCP descriptions consistent with the implementation. Do not edit `review.md` to hide findings.
+
+At handoff, provide:
+
+- a concise mapping of HARD01 IDs to the implemented change and tests;
+- commands run and their outcomes;
+- any intentionally deferred hardware-only validation, with reason;
+- an explicit statement that all 35 findings were implemented, or a precise list of any remaining IDs and the blocker. Do not claim completion while any HARD01-001..035 finding remains unresolved.

--- a/doc/reviews/hardening/01-fable/review-prompt.md
+++ b/doc/reviews/hardening/01-fable/review-prompt.md
@@ -1,0 +1,468 @@
+You are Anthropic Fable acting as an exceptionally strong MCP-server reviewer, TypeScript/Node.js reliability engineer, adversarial protocol tester, C64 Ultimate/U2 integration specialist, VICE Binary Monitor expert, and product-minded reviewer for C64 Bridge.
+
+You are starting a review-only hardening pass:
+
+# Hardening 01 - Whole-server Fable bug review
+
+Repository: /home/chris/dev/c64/c64bridge
+
+Required review artifact: /home/chris/dev/c64/c64bridge/doc/reviews/hardening/01-fable/review.md
+
+This is review-only. Do not implement fixes, edit production code, tests, generated artifacts, skills, prompts, configuration, or packaging files, or create an implementation branch. The review document is the product. It is the only normal file you may edit, plus a timestamped backup when continuing an existing report.
+
+Fable credits may run out. As soon as a bug is confirmed enough to report, write it to review.md before investigating another lead. Do not keep confirmed bugs only in private reasoning.
+
+## Non-negotiable objective
+
+Find at least **30 confirmed, production-relevant bugs** across the complete C64 Bridge server.
+
+Do not stop at 5, 10, 15, or 20 findings, or after a strong cluster in one subsystem. Stop below 30 only if:
+
+1. A low-credit, quota, rate-limit, spend, model-availability, or tool-instability warning occurs.
+2. The source genuinely cannot support 30 findings at the required quality bar.
+3. The risk-first, distribution, and broad-sweep passes are complete and further reports would be speculative.
+
+If fewer than 30 findings are confirmed, explain why under “Important limitations”. Never invent weak findings. Put unproven but worthwhile concerns only in “Leads not yet proven”.
+
+## C64 Bridge context
+
+C64 Bridge is a Node.js/TypeScript stdio Model Context Protocol server, not a UI application. Its public contract is its MCP tools, resources, prompts, generated metadata, README, and execution instructions in .github/skills/.
+
+It controls three runtime-selectable backends:
+
+| Backend | Target | Critical boundary |
+|---|---|---|
+| c64u | C64 Ultimate / Ultimate 64 | Firmware REST, physical machine input/menu, streams, persistent config, physical drives. |
+| u2 | U2, U2+, U2+L | Firmware REST subset; no physical machine input, debug registers, power-off, or streaming. |
+| vice | VICE emulator | Binary Monitor transport and process lifecycle; no Ultimate REST API or firmware filesystem/config. |
+
+c64_select_backend changes the active backend without restarting the server. Treat backend identity, capability enforcement, global platform state, in-flight work, facade lifecycle, and stateful resources as high risk.
+
+VICE work must account for its Binary Monitor’s single-client constraint, framing/request IDs, unsolicited events, and trap/resume effects. Read doc/vice/vice-binary-monitor-spec.md before tracing a VICE flow.
+
+Grouped MCP tools must receive an explicit op. Schemas, registry dispatch, runtime platform gating, generated MCP artifacts, README tables, skills, and actual implementation must agree.
+
+The principal implementation areas are src/mcp-server.ts, src/c64Client.ts, src/device.ts, src/vice/, src/tools/, src/tools/registry/, src/tools/meta/, src/rag/, and src/prompts/. Treat a real C64/U64, a real U2-family device, managed and unmanaged VICE, concurrent MCP calls, mid-call client disconnect, and server shutdown as production environments.
+
+## Artifact setup
+
+Run:
+
+~~~bash
+cd /home/chris/dev/c64/c64bridge
+git status --short
+git rev-parse --abbrev-ref HEAD
+git rev-parse HEAD
+date -Iseconds
+mkdir -p doc/reviews/hardening/01-fable
+if test -f doc/reviews/hardening/01-fable/review.md; then
+  cp doc/reviews/hardening/01-fable/review.md doc/reviews/hardening/01-fable/review.md.bak.$(date +%Y%m%d-%H%M%S)
+  grep -o 'HARD01-[0-9][0-9][0-9]' doc/reviews/hardening/01-fable/review.md | sort -u
+fi
+~~~
+
+When review.md does not exist, create it with:
+
+~~~markdown
+# Hardening 01 - Whole-server Fable bug review
+
+## Baseline
+
+- Review date:
+- Branch:
+- Commit:
+- Working tree status:
+- Review mode: Review only. No implementation.
+- Model: Anthropic Fable
+- Required artifact: doc/reviews/hardening/01-fable/review.md
+
+## Executive summary
+
+## Findings count
+
+| Severity | Count |
+|---|---:|
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+| P3 | 0 |
+| Total | 0 |
+
+## Findings by area
+
+| Area | Target | Confirmed |
+|---|---:|---:|
+| MCP protocol, stdio, tool dispatch, prompts, and resources | 3-5 | 0 |
+| Backend selection and platform/capability contract | 3-5 | 0 |
+| Ultimate REST, machine control, configuration, and input | 4-6 | 0 |
+| VICE Binary Monitor and process lifecycle | 4-6 | 0 |
+| Program execution, BASIC, assembler, memory, graphics, and SID | 4-6 | 0 |
+| Drives, storage, printers, streams, and state verification | 3-5 | 0 |
+| Background tasks, meta workflows, artifacts, and cancellation | 3-5 | 0 |
+| RAG, external acquisition, paths, diagnostics, and secrets | 3-5 | 0 |
+| Packaging, generated contract, documentation, and broad sweep | 3-5 | 0 |
+
+## Findings index
+
+| ID | Title | Area | Severity | Dimensions | Confidence | Effort | Status |
+|---|---|---|---|---|---|---|---|
+
+## Detailed findings
+
+## Suggested fix batches
+
+## Recommended validation gate
+
+## Leads not yet proven
+
+## Important limitations
+
+## Commands run
+~~~
+
+When the file already exists:
+
+1. Read it and back it up before editing.
+2. Find the highest existing HARD01-NNN and continue from the next ID.
+3. Preserve confirmed findings and IDs. Do not renumber them.
+4. Do not rewrite detailed findings other than correcting a demonstrable factual error.
+5. You may update summaries, counts, the area table, index, batches, validation, commands, and limitations.
+6. Never truncate or overwrite the existing report with cat >, tee, or an equivalent whole-file replacement.
+
+## Absolute constraints
+
+* Do not implement or test a proposed fix.
+* Do not modify production source, tests, generated files, skills, prompts, API specs, documentation outside this review folder, or configuration.
+* Do not perform state-changing MCP calls against hardware or VICE for exploration.
+* Do not reset, reboot, power-cycle, pause, mount, unmount, write memory/configuration, inject input, start streams, or launch software on a user device.
+* Do not use subagents, background agents, parallel reviews, delegation, or a Task tool.
+* Do not perform broad tool discovery, build a huge architecture map, or read old hardening reviews without a specific duplicate-checking need.
+* Do not report missing tests, generic cleanup, style issues, or feature wishes as main findings without a separately proven production bug.
+* Do not report low-confidence speculation as a main finding.
+* Do not disclose credentials, raw X-Password values, secrets from config, or sensitive diagnostic content.
+
+Prefer focused inspection:
+
+~~~bash
+rg "term" src test doc .github/skills
+git grep "term"
+sed -n 'START,ENDp' path/to/file
+nl -ba path/to/file | sed -n 'START,ENDp'
+find src -maxdepth 3 -type f | sort
+~~~
+
+A narrow non-mutating test is allowed only when a specific source finding already justifies it:
+
+~~~bash
+npm test -- test/specific.test.mjs
+node scripts/invoke-bun.mjs scripts/run-tests.ts -- test/specific.test.mjs
+~~~
+
+Do not use broad suites as exploration unless the user changes scope:
+
+~~~bash
+npm test
+npm run test
+npm run check
+npm run build
+npm run lint
+npm run coverage
+npm run test:matrix
+./build test
+./build check
+~~~
+
+## Objective and severity
+
+Find failures that can corrupt MCP protocol output; hang requests; return false success/failure; control a wrong target; violate a backend contract; leave hardware or VICE in an unsafe state; corrupt/expose data; or prevent reliable BASIC/6510 development and validation.
+
+* **P0:** stdout protocol corruption; wrong-target or uncontrolled physical state change; persistent data/config loss; serious secret disclosure; or a common workflow wedges all later device/VICE control until restart or power intervention.
+* **P1:** common false success/failure, serious lifecycle defect, practical security boundary failure, unbounded leak, or unreliability in a high-value run/mount/input/config action.
+* **P2:** narrower concrete race, timeout/cancellation defect, stale state, false validation, contract mismatch, or unsafe recovery affecting a real workflow.
+* **P3:** actionable lower-frequency robustness, platform-gating, release-contract, diagnostic, or documentation-to-execution defect.
+
+Use only relevant dimensions:
+
+mcp-protocol, stdio, tool-contract, schema-validation, backend-switching, capability, c64u-rest, u2-variant, vice-monitor, vice-lifecycle, concurrency, timeout-cancellation, device-safety, physical-state, input, config, drive, streaming, program-runner, basic, 6510, memory-io, graphics, sid-audio, background-task, filesystem, security, secrets, rag, diagnostics, persistence, packaging, documentation-contract.
+
+A valid finding is grounded in current source, production or release reachable, specific enough for a safe mental/tiny-test reproduction, tied to an actual user impact, actionable with a minimal fix, and immediately persisted.
+
+Confidence:
+
+* **High:** Full current code path to the failure is traced.
+* **Medium:** Strong source evidence with one explicitly stated inference supported by the documented contract.
+* **Low:** Leads only.
+
+## Required working method
+
+Use a single-agent flow loop:
+
+1. Choose a concrete MCP request and target backend/state.
+2. Trace MCP schema → registry/handler → client/facade → transport/device.
+3. Trace success, error, timeout, cancellation, cleanup, diagnostics, and final MCP response.
+4. Check grouped op, platform support, capability status, skill/prompt instruction, generated metadata, and promised read-back/verification at each boundary.
+5. Check concurrency, backend switching, disconnect, shutdown, stale sockets/processes, and unavailable endpoints when relevant.
+6. Write every confirmed finding immediately with the next HARD01-NNN ID.
+7. Promptly update the index, counts, area table, summary, batches, validation gate, and commands.
+8. After roughly eight source files or two tightly related tests without a solid finding, record a short lead only if useful and change flow.
+
+Treat unrelated dirty-worktree changes as user-owned; do not alter or discard them.
+
+## Distribution and layers
+
+Review the complete server. Targets are coverage guides, never an excuse to lower quality:
+
+| Area | Target confirmed |
+|---|---:|
+| MCP protocol, stdio, tool dispatch, prompts, and resources | 3-5 |
+| Backend selection and platform/capability contract | 3-5 |
+| Ultimate REST, machine control, configuration, and input | 4-6 |
+| VICE Binary Monitor and process lifecycle | 4-6 |
+| Program execution, BASIC, assembler, memory, graphics, and SID | 4-6 |
+| Drives, storage, printers, streams, and state verification | 3-5 |
+| Background tasks, meta workflows, artifacts, and cancellation | 3-5 |
+| RAG, external acquisition, paths, diagnostics, and secrets | 3-5 |
+| Packaging, generated contract, documentation, and broad sweep | 3-5 |
+
+After each area ask whether at least one complete supported flow, its success/error/cleanup, backend interactions, and all confirmed findings were covered. If the area is low-yield, document that and continue.
+
+Perform three layers:
+
+1. Risk-first deep passes over protocol boundaries, backend switching, physical state changes, and VICE lifecycle.
+2. A distribution pass over every tool domain, especially program-development and meta/background paths.
+3. A broad sweep over registries, public metadata, resources/prompts, scripts, package contents, generated-contract inputs, test-only boundaries, and host/platform behaviour.
+
+## Priority 1 - MCP protocol, stdio, dispatch, resources, and prompts
+
+Inspect src/mcp-server.ts, src/bootstrap/stdio-logger.ts, logging/diagnostics, every MCP request handler, result/error conversion, registry dispatch, prompt/resource registries, data/context/, .github/prompts/, and .github/skills/.
+
+Look for:
+
+* Non-protocol stdout, rejected handler promises, malformed result serialization, or hung requests.
+* Schema/operation/alias/dispatcher disagreement, especially a missing or incorrectly forwarded op.
+* Tool metadata/platform support differing from runtime enforcement.
+* Resource/prompt output using stale or incorrect active-backend context.
+* Skills promising a tool call, safety guard, or validation that current exposed tools cannot perform.
+* Sensitive arguments, paths, binary payloads, or credentials leaking through logs, diagnostics, or errors.
+
+## Priority 2 - Backend selection and capability contract
+
+Inspect src/c64Client.ts, src/device.ts, src/platform.ts, src/tools/registry/platform.ts, configuration parsing, facade construction, prewarming, and c64://platform/status. Compare a suspected mismatch with doc/vice/support-matrix.md, generated artifacts, and README only as needed.
+
+Look for:
+
+* Concurrent requests switching the backend mid-operation, returning an availability summary for the wrong target, or using global state unsafely.
+* Facades, streams, sockets, endpoint-probe results, or capabilities surviving a switch to act on the previous target.
+* U2 invoking physical input/debug/power-off/stream functions forbidden by its contract.
+* Supported VICE behaviour rejected, or unsupported VICE behaviour reaching hardware-only code.
+* Incorrect profile/environment host, port, or password precedence.
+* Prewarm/lazy-start/probe failure creating a permanent false-unavailable state.
+
+## Priority 3 - Ultimate REST, machine control, configuration, and input
+
+Inspect C64 Ultimate and U2 REST facade code, generated client use, machine reset/reboot/power/menu sequences, machine:input probing and release-all, key/text fallback, config operations, drive/file/stream calls, and verification/retry logic.
+
+Look for:
+
+* Success reported before a device confirmation or after a partial firmware result.
+* Exception/cancellation leaving injected keys/joystick controls held, a menu open, or the machine paused.
+* Power-cycle Tool Menu navigation continuing after screen verification failure or assuming C64U behaviour on U2.
+* Missing endpoint, auth failure, malformed response, or network timeout misclassified as success, unsupported, or another backend.
+* Partial config batches, unsafe snapshots/restores, or persistent flash actions missing the promised guard.
+* Parallel REST calls producing unsafe final physical state or excessive firmware load.
+* Capture/stream resources persisting after errors, switch, or disconnect.
+
+## Priority 4 - VICE Binary Monitor and process lifecycle
+
+Read doc/vice/vice-binary-monitor-spec.md first. Inspect src/vice/viceClient.ts, src/device.ts VICE facade, src/vice/process.ts, readiness/runner code, and VICE debug/resource tools.
+
+Look for:
+
+* Multiple monitor clients or interleaved commands despite VICE’s single-client constraint.
+* Disconnect, timeout, parser, or rejected-command paths leaving a mutex locked, stale pending requests, or a falsely usable client.
+* Stopped/resumed/checkpoint asynchronous events resolving the wrong request, being lost, or leaving VICE trapped.
+* Reset/run/autostart/feed/display/debug operations racing and falsely validating program state.
+* Managed versus unmanaged process confusion, unsafe kill/restart, failed X11/Xvfb handling, process leak, or permanent dead backend.
+* Resource/checkpoint state leaking across newly launched instances or backend switches.
+
+## Priority 5 - Program execution and C64 development workflows
+
+Inspect program runners, tokenizer, assembler/disassembler, symbols/opcodes, memory/screen polling, PETSCII, graphics/bitmap/sprite code, SID/audio, and skills for hello world, BASIC, assembly, graphics, SID, memory debug, and software launch.
+
+Look for:
+
+* BASIC tokenization/load/run semantics diverging from claims: quoting, control codes, line numbers, pointers, or termination.
+* Assembler, branch/address, undocumented-opcode, symbols, PRG header/load-address bugs reporting successful but corrupt code.
+* Unsafe writes to live ROM/I/O/shared/code memory without the promised pause/read-back.
+* Screen/memory verification false positive/negative due to charset, PETSCII, display timing/mode, pause, or stale data.
+* VIC-II/SID/CIA functionality claiming portable behaviour where a backend differs.
+* A workflow overwriting a session, repeating after timeout, leaving a machine paused, or validating another backend.
+* Capture encoding/timeouts/artifacts misrepresenting results or leaking resources.
+
+## Priority 6 - Drives, storage, printers, streams, and verification
+
+Inspect disk/drive/storage registries, mount/unmount/create/find/run, VICE drive resources, printer routines, stream start/stop, capture/artifact paths, and the related skills.
+
+Look for:
+
+* Wrong drive/backend targets, unverified final state, or retry loops duplicating mount/reset/physical work.
+* Firmware, host-local, and VICE paths being confused or crossing a trust boundary.
+* VICE drive-resource behaviour treated as Ultimate filesystem behaviour.
+* Stream/capture sockets, printer work, or temporary artifacts persisting after stop/error/disconnect.
+* Program launch assuming drive state that another tool can mutate.
+
+## Priority 7 - Background tasks, meta workflows, artifacts, and cancellation
+
+Inspect src/tools/meta/, task persistence/lifecycle, batch runs, artifact bundles, snapshots, diagnostics reports, compilation/filesystem helpers, server shutdown, and signal behaviour.
+
+Look for:
+
+* Cancelled/stopped tasks continuing device or child-process work.
+* Success reported while a nested tool failed, or a failure hiding a completed destructive action.
+* Concurrent tasks mixing backends, results, logs, or artifact paths; duplicate task starts; lost task state; unbounded live work.
+* Artifacts/snapshots escaping their intended path, overwriting unrelated files, or presenting incomplete/stale data as valid.
+* Batch/assertion flows continuing destructive steps after failure or timeout.
+* Diagnostic/report calls exposing unrelated filesystem or session data.
+
+## Priority 8 - RAG, external acquisition, paths, diagnostics, and secrets
+
+Inspect src/rag/, URL normalisation/fetch/index/retrieval/rate limiting, knowledge resources, configuration resolution, filesystem/storage/extraction, logging HTTP client, diagnostics, and package data paths.
+
+Look for:
+
+* SSRF, unsafe URL schemes/redirects, local-network access, archive traversal, arbitrary file read/write, path traversal, or workspace/home escape.
+* Lazy cache or fetch/index failure poisoning all later calls, blocking requests, duplicating work, or returning incorrect source content.
+* Concurrent initialisation/rate limiting leaking promises or stalling service.
+* Host/password/backend-profile precedence errors or secrets in errors/diagnostics/logs.
+* Diagnostic destination failure crashing the server or allowing retrieval of unrelated local data.
+
+## Priority 9 - Packaging, generated contract, documentation, and broad sweep
+
+Inspect package.json, entry scripts, build/generation scripts, mcp/, generated OpenAPI clients, README generated blocks, server.json, .mcp.json, VS Code config, all registries, and public operations not already covered.
+
+Look for:
+
+* An installed package that cannot start, exposes a different tool set from source, or omits required runtime files.
+* Generated API/MCP/README metadata drifting from runtime enforcement or the VICE support matrix.
+* Public examples starting an incorrect entrypoint, writing logs to stdout, silently selecting a target, or failing on claimed host platforms.
+* Mock-only/probe/experimental behaviour exposed publicly, or required VICE functionality only working in mocks.
+* Unsafe/unusable environment parsing or cross-platform script assumptions.
+
+## Duplicate handling
+
+Keep findings separate when user flow, backend, transport/endpoint, physical consequence, persistence, lifecycle, recovery, fix location, or regression test differs. Combine only identical root causes with the same visible failure.
+
+Before adding one, check the index and relevant details. If related but distinct, explicitly say why.
+
+## Required finding format
+
+Use HARD01-001, HARD01-002, and so on.
+
+~~~markdown
+### HARD01-00N - Title
+
+- **Area:**
+- **Severity:**
+- **Dimensions:**
+- **Confidence:** High/Medium
+- **Effort:** S/M/L
+- **Status:** OPEN
+- **Files/functions reviewed:**
+
+**Failure scenario:**  
+Concrete MCP request, backend state, and user-visible result.
+
+**Current-code evidence:**  
+Precise file/function/line anchors. No large code blocks.
+
+**Why production-reachable:**  
+Supported client, documented workflow, or release/runtime path.
+
+**Why this degrades C64 control, development, or trust:**  
+Protocol, safety, emulator, program correctness, data, or security impact.
+
+**Backend and recovery angle:**  
+Relevant C64U/U64, U2, VICE, switch, timeout, disconnect, or restart behaviour.
+
+**Relation to existing HARD01 findings:**  
+Independent or related, and why still distinct.
+
+**Why existing tests missed it:**  
+Only if known from focused inspection.
+
+**Minimal fix sketch:**  
+Smallest defensible change. Do not implement it.
+
+**Regression test strategy:**  
+Specific focused unit, integration, VICE-BM, mock, or HIL test.
+
+**Hardware validation:**  
+Only if relevant: C64U, U64, U2, managed VICE, or unmanaged VICE.
+
+**Fix risk:**  
+Principal regression risk.
+~~~
+
+Immediately update counts, area totals, index, summary, batches, validation gate, and commands after each finding.
+
+## Suggested fix batches and validation gate
+
+Create coherent fix batches once several related findings emerge. Example:
+
+~~~markdown
+### Batch A - Backend-switch and capability isolation
+
+- HARD01-001
+- HARD01-006
+- HARD01-014
+
+Rationale:
+- They share active-backend isolation and capability reporting.
+- One multi-backend integration harness can protect the group.
+~~~
+
+Maintain a targeted—not generic—validation gate tied to findings. Appropriate entries include:
+
+* Focused schema/platform/error-conversion tests.
+* An stdio MCP request checking framing and error semantics.
+* A concurrent backend-switch test using mock configured C64U/U2/VICE facades.
+* A VICE BM stub test covering disconnect, unsolicited events, timeout, and queue release.
+* Managed and unmanaged VICE lifecycle checks where relevant.
+* Mock Ultimate tests for missing endpoint, auth/partial response, and input release cleanup.
+* A BASIC/assembler/memory fixture with specific screen/memory assertions.
+* URL/path/diagnostic-redaction tests.
+* A controlled HIL validation only after a fix where hardware is indispensable; never perform it during this review.
+
+## Leads not yet proven
+
+Use only for concise, important unconfirmed leads:
+
+~~~markdown
+- **Lead:**
+  - **Area:**
+  - **Why it matters:**
+  - **Evidence so far:**
+  - **Next check:**
+~~~
+
+## Session survival protocol
+
+On a low-credit, quota, rate-limit, spend, model-availability, or tool-instability warning—or if allowance becomes uncertain—stop analysis immediately and finalise review.md.
+
+Finalisation means every confirmed finding is on disk; counts, area totals, and index are correct; each finding has severity/confidence/effort/status; batches and validation are current; limitations explain any count below 30; and a recommended next step is recorded. Do not hunt one more bug after the warning.
+
+## Final response
+
+Return only:
+
+* Review document path.
+* Backup path, if any.
+* Findings by severity and area.
+* Full findings index with every ID and title.
+* Suggested fix batches.
+* Recommended validation gate.
+* Commands run.
+* Important limitations.
+
+Do not give a long narrative or only the top five findings.
+

--- a/doc/reviews/hardening/01-fable/review.md
+++ b/doc/reviews/hardening/01-fable/review.md
@@ -1,0 +1,1234 @@
+# Hardening 01 - Whole-server Fable bug review
+
+## Baseline
+
+- Review date: 2026-07-19T17:55:22+01:00
+- Branch: fix/hardening
+- Commit: da8b5c855f6f712471822466618322fd15a9f2b2
+- Working tree status: clean except untracked doc/reviews/hardening/
+- Review mode: Review only. No implementation.
+- Model: Anthropic Fable
+- Required artifact: doc/reviews/hardening/01-fable/review.md
+
+## Executive summary
+
+31 confirmed, production-relevant defects across every C64 Bridge subsystem: 5 P1, 18 P2, 8 P3, no P0. The dominant themes are (1) **false success** — Ultimate REST methods report success on any 2xx while ignoring the firmware `errors` array (HARD01-011), `upload_run_asm` runs machine code that never actually executes (HARD01-018) behind a crash-detector that can never fire (HARD01-019), and printer/BASIC generators emit invalid CBM BASIC (HARD01-007) — ; (2) **lifecycle and cancellation gaps** in VICE (no BM response timeout wedges the whole backend, HARD01-012; orphaned VICE/Xvfb on exit, HARD01-013) and in background/detached work (HARD01-022, HARD01-030); (3) **backend-switch and config consistency** (in-flight operations retargeting across `c64_select_backend`, HARD01-016; two divergent config loaders resolving different hosts, HARD01-005; cwd-vs-package path resolution breaking config and RAG for installed users, HARD01-006/025); and (4) **input/physical-state hazards** (blind Tool-Menu RETURN in power_cycle, HARD01-002; VICE joystick writes that do nothing, HARD01-014; keystroke loss on drain timeout, HARD01-009). Also present: a secrets-in-logs leak (HARD01-024) and an artifact path traversal (HARD01-029).
+
+A codebase-wide arithmetic bug (HARD01-032) makes every SID note ~256x too low in pitch because the frequency register formula uses 2^16 instead of the SID's 2^24 phase-accumulator divisor; the wrong formula is also copied into the knowledge docs.
+
+Highest-priority fixes: HARD01-011 (systemic false success on hardware), HARD01-012 (permanent VICE wedge), HARD01-018 (assembly workflow never executes), HARD01-032 (SID pitch off by 256x), HARD01-014 (VICE joystick no-op), HARD01-002 (uncontrolled physical menu action).
+
+## Findings count
+
+| Severity | Count |
+|---|---:|
+| P0 | 0 |
+| P1 | 5 |
+| P2 | 19 |
+| P3 | 11 |
+| Total | 35 |
+
+## Findings by area
+
+| Area | Target | Confirmed |
+|---|---:|---:|
+| MCP protocol, stdio, tool dispatch, prompts, and resources | 3-5 | 1 |
+| Backend selection and platform/capability contract | 3-5 | 6 |
+| Ultimate REST, machine control, configuration, and input | 4-6 | 5 |
+| VICE Binary Monitor and process lifecycle | 4-6 | 6 |
+| Program execution, BASIC, assembler, memory, graphics, and SID | 4-6 | 8 |
+| Drives, storage, printers, streams, and state verification | 3-5 | 2 |
+| Background tasks, meta workflows, artifacts, and cancellation | 3-5 | 4 |
+| RAG, external acquisition, paths, diagnostics, and secrets | 3-5 | 2 |
+| Packaging, generated contract, documentation, and broad sweep | 3-5 | 1 |
+
+## Findings index
+
+| ID | Title | Area | Severity | Dimensions | Confidence | Effort | Status |
+|---|---|---|---|---|---|---|---|
+| HARD01-001 | Documented `--http` mode parsed but never wired | Packaging/docs | P3 | documentation-contract, mcp-protocol | High | S | OPEN |
+| HARD01-002 | power_cycle presses RETURN after blind cursor moves; no highlight verification | Ultimate | P1 | device-safety, physical-state, input | High | M | OPEN |
+| HARD01-003 | power_cycle failure leaves Ultimate menu open, no cleanup | Ultimate | P2 | device-safety, timeout-cancellation | High | S | OPEN |
+| HARD01-004 | Transient probe errors permanently cache machine:input as "unknown" | Backend/capability | P2 | capability, c64u-rest | High | S | OPEN |
+| HARD01-005 | Divergent config loaders resolve different hosts | Backend/capability | P2 | config, backend-switching | High | M | OPEN |
+| HARD01-006 | `./.c64bridge.json` resolved package-relative, not cwd | Backend/capability | P2 | config, documentation-contract | High | S | OPEN |
+| HARD01-007 | Printer quote-doubling is invalid CBM BASIC; runtime SYNTAX ERROR with reported success | Drives/printers | P2 | basic, program-runner | High | S | OPEN |
+| HARD01-008 | PETSCII "wait for key" never waits; READY. corrupts rendered screen | Program execution | P3 | basic, graphics | High | S | OPEN |
+| HARD01-009 | injectKeyboardQueue silently drops keys on drain timeout | Ultimate/input | P2 | input, timeout-cancellation | High | S | OPEN |
+| HARD01-010 | files endpoints double-encode device paths (slashes) | Ultimate | P2 | c64u-rest, filesystem | Medium | S | OPEN |
+| HARD01-011 | C64u/U2 facade ignores `errors` array in 200 responses | Ultimate | P1 | c64u-rest, tool-contract | Medium | M | OPEN |
+| HARD01-012 | ViceClient lacks response timeout; lost frame wedges all VICE ops | VICE | P1 | vice-monitor, timeout-cancellation | High | M | OPEN |
+| HARD01-013 | Managed VICE/Xvfb orphaned on server exit/termination | VICE | P2 | vice-lifecycle, filesystem | High | M | OPEN |
+| HARD01-014 | VICE joystick writes CIA ports (no-op); BM Joyport Set unimplemented | VICE | P1 | input, vice-monitor, tool-contract | High | M | OPEN |
+| HARD01-015 | checkpointCreate silently adds execute flag to watchpoints | VICE | P3 | vice-monitor, tool-contract | High | S | OPEN |
+| HARD01-016 | Platform gating and multi-step flows race with c64_select_backend | Backend/capability | P2 | backend-switching, concurrency | High | M | OPEN |
+| HARD01-017 | Write-verify leaves machine paused with success when resume fails | Program execution | P2 | memory-io, physical-state | High | S | OPEN |
+| HARD01-018 | upload_run_asm has no SYS/stub entry; ML never executes, success reported | Program execution | P1 | program-runner, 6510 | High | M | OPEN |
+| HARD01-019 | ASM crash detection dead: raster/CIA timers make every machine "alive" | Program execution | P2 | program-runner, tool-contract | High | S | OPEN |
+| HARD01-020 | ASM polling DMA-reads CIA ICRs, clearing pending IRQs on hardware | Program execution | P2 | memory-io, device-safety | Medium | S | OPEN |
+| HARD01-021 | BASIC polling false-fails programs that print "ERROR" | Program execution | P3 | basic, tool-contract | High | S | OPEN |
+| HARD01-022 | Persisted running tasks never rescheduled after restart | Background tasks | P2 | background-task, persistence | High | M | OPEN |
+| HARD01-023 | drive_mount_and_verify assumes VICE drive shape; fails on hardware | Drives/storage | P2 | drive, c64u-rest | High | M | OPEN |
+| HARD01-024 | Debug HTTP logging leaks raw X-Password header | RAG/secrets | P3 | secrets, diagnostics | High | S | OPEN |
+| HARD01-025 | RAG paths resolved from cwd; installed server returns empty retrievals | RAG/paths | P2 | rag, filesystem, packaging | High | M | OPEN |
+| HARD01-026 | VICE reset reports success even when BASIC never reaches READY | VICE | P2 | vice-lifecycle, tool-contract | High | S | OPEN |
+| HARD01-027 | Malformed C64BRIDGE_CONFIG JSON crashes server at startup | Backend/capability | P3 | config, diagnostics | High | S | OPEN |
+| HARD01-028 | Background task {success:false} iterations counted as healthy | Background tasks | P3 | background-task, tool-contract | High | S | OPEN |
+| HARD01-029 | bundle_run_artifacts path traversal via unsanitised runId | Background tasks | P2 | filesystem, security | High | S | OPEN |
+| HARD01-030 | c64_sound generate spawns untracked uncancellable playback loop | Background tasks | P2 | sid-audio, timeout-cancellation | High | M | OPEN |
+| HARD01-031 | platform/status resource read blocks on device REST probe | MCP protocol | P3 | mcp-protocol, c64u-rest | High | S | OPEN |
+| HARD01-032 | SID frequency formula uses 2^16 not 2^24; notes ~256x too low | Program execution | P2 | sid-audio, tool-contract | High | S | OPEN |
+| HARD01-033 | music_generate never re-gates; ADSR attacks only once | Program execution | P3 | sid-audio, tool-contract | High | S | OPEN |
+| HARD01-034 | Printer tools gated to c64u only, excluded on u2 despite advertised feature | Backend/capability | P3 | capability, u2-variant | High | S | OPEN |
+| HARD01-035 | VICE configSet coerces digit-strings to ints, misapplying string resources | VICE | P3 | config, vice-monitor | Medium | S | OPEN |
+
+## Detailed findings
+
+### HARD01-001 - Documented `--http` server mode is parsed but never wired; `npm start -- --http` silently runs stdio
+
+- **Area:** Packaging, generated contract, documentation, and broad sweep
+- **Severity:** P3
+- **Dimensions:** documentation-contract, mcp-protocol, packaging
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/mcp-server.ts (`parseCliOptions` line 60, `main` line 80), doc/developer.md:114
+
+**Failure scenario:**
+A user follows doc/developer.md ("enable with `npm start -- --http [port]` for manual curl experiments"). The server prints "running on stdio", never opens an HTTP listener, and curl requests fail. Any port argument is silently ignored.
+
+**Current-code evidence:**
+`parseCliOptions`/`parsePort` (src/mcp-server.ts:60-78) are defined but never called; `main()` unconditionally constructs `StdioServerTransport` (src/mcp-server.ts:493). `createServer` (node:http) and `StreamableHTTPServerTransport` are imported (lines 3, 8) and never used. `createPromptRegistryGetter` (line 48) is likewise created at line 136 and never used.
+
+**Why production-reachable:**
+doc/developer.md documents the flag; the dist entrypoint is the shipped `bin`.
+
+**Why this degrades C64 control, development, or trust:**
+Documented troubleshooting path is a no-op; a user debugging MCP issues loses time and may conclude the server is broken.
+
+**Backend and recovery angle:** Backend-independent.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Either wire `parseCliOptions` + `StreamableHTTPServerTransport` into `main`, or remove the dead code and the doc claim.
+
+**Regression test strategy:** Unit test asserting `parseCliOptions(["--http","8080"])` result is honoured by the transport selection function once factored out.
+
+**Fix risk:** Low; dead-code removal or isolated transport branch.
+
+### HARD01-002 - C64U power_cycle presses RETURN after four blind cursor moves; menu verification cannot detect the highlighted item
+
+- **Area:** Ultimate REST, machine control, configuration, and input
+- **Severity:** P1
+- **Dimensions:** device-safety, physical-state, input, c64u-rest
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `powerCycle` (968-1025), `readVerifiedMenuScreen` (1031-1048), `menuMatrixIncludes` (89-97)
+
+**Failure scenario:**
+`c64_system` op `power_cycle` on a C64U/U64 whose Tool Menu has a different item count/order than the hard-coded assumption (firmware revision change, different item set). The code taps `cursor_up_down` exactly 4 times and then taps `return`, activating whatever item is highlighted — potentially a different Tool Menu action — while reporting `success: true, selectedItem: "Power Cycle"`.
+
+**Current-code evidence:**
+src/c64Client.ts:1001-1010: a fixed `for (let index = 0; index < 4; ...)` loop; each `readVerifiedMenuScreen` call only checks (a) matrix non-empty, (b) matrix changed vs previous, and (c) the string "POWER CYCLE" appears **anywhere** in the 40×25 character matrix (`menuMatrixIncludes` inspects only characters, never the colour matrix that encodes the highlight). Nothing verifies the *selected* row before the final `return` tap at line 1010.
+
+**Why production-reachable:**
+`c64_system power_cycle` is a documented tool op; AGENTS.md explicitly promises it "reads `machine:menu_screen` after every navigation step and stops rather than blindly selecting an unverified item". The implementation verifies screen presence, not selection, so the promise is not kept.
+
+**Why this degrades C64 control, development, or trust:**
+Uncontrolled physical state change: activating an arbitrary Tool Menu entry can flash firmware menus, change settings, or leave the device in an unexpected mode; the tool still reports verified success.
+
+**Backend and recovery angle:**
+C64U/U64 only (u2 uses REST reboot, VICE restarts the process). No recovery logic exists after the final RETURN.
+
+**Relation to existing HARD01 findings:** Related to HARD01-003 (same flow) but distinct root cause: this is missing selection verification; 003 is missing failure cleanup.
+
+**Minimal fix sketch:** Parse the colour matrix (bytes 1000-1999) to locate the highlighted row and assert it contains "POWER CYCLE" before the final RETURN; abort otherwise.
+
+**Regression test strategy:** Mock-Ultimate test feeding menu_screen matrices where "POWER CYCLE" is visible but a different row is highlighted; assert the flow aborts without the final RETURN input event.
+
+**Hardware validation:** C64U/U64 after fix, using a Tool Menu screen dump.
+
+**Fix risk:** Colour-matrix highlight encoding must be confirmed against firmware; keep abort-on-uncertain semantics.
+
+### HARD01-003 - power_cycle failure paths leave the Ultimate menu open with no cleanup
+
+- **Area:** Ultimate REST, machine control, configuration, and input
+- **Severity:** P2
+- **Dimensions:** device-safety, physical-state, timeout-cancellation
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `powerCycle` (968-1025)
+
+**Failure scenario:**
+During Tool Menu navigation, any step fails (screen didn't change, expected text missing, input REST error, network timeout). `powerCycle` throws/returns `success:false` — but the Ultimate menu (and possibly the Tool Menu submenu) remains open on the physical machine. The running C64 program stays frozen behind the menu until a human intervenes; subsequent tools that assume a running machine (screen reads, key input) act on the menu instead.
+
+**Current-code evidence:**
+src/c64Client.ts:992-1011: after `facade.menuButton()` opens the menu, every later failure propagates to the catch at 1012-1024, which only classifies the error. There is no compensating `menuButton()`/escape tap or release-all in any failure path.
+
+**Why production-reachable:**
+Any transient REST failure or an unexpected menu layout mid-flow triggers it.
+
+**Why this degrades C64 control, development, or trust:**
+Machine is left in a menu state the caller did not request; later `read_screen`/`wait_for_text` calls poll the frozen C64 screen (menu overlays are separate) or key input lands in the menu, producing confusing follow-on failures and potentially unintended menu actions.
+
+**Backend and recovery angle:** C64U/U64 only. Recovery requires a human or an explicit follow-up `menuButton` call the agent has no instruction to make.
+
+**Relation to existing HARD01 findings:** Complements HARD01-002; distinct defect (missing failure cleanup vs missing selection verification).
+
+**Minimal fix sketch:** Wrap navigation in try/finally; on failure attempt a best-effort menu close (menu button tap or repeated `runstop`/escape input) and record whether cleanup succeeded in details.
+
+**Regression test strategy:** Mock-Ultimate test forcing a verification failure at each step, asserting a closing menu_button call is issued.
+
+**Hardware validation:** C64U/U64.
+
+**Fix risk:** Cleanup taps must be safe if the menu already closed; keep them idempotent.
+
+### HARD01-004 - Transient probe errors permanently cache machine:input availability as "unknown" until server restart
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P2
+- **Dimensions:** capability, c64u-rest, backend-switching
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `getNativeEndpointCapabilities` (259-276), `machineInputCapabilityProbes` map (197)
+
+**Failure scenario:**
+The first read of `c64://platform/status` (or any powerCycle attempt) happens while the C64U is booting or briefly unreachable. The GET `machine:input` probe fails with a timeout (not 404), so the probe promise resolves `"unknown"` — and is cached in `machineInputCapabilityProbes` forever. Every later status read and every `power_cycle` (which requires `"available"`, line 981) reports native input unavailable for the whole server lifetime, even though the device is now healthy.
+
+**Current-code evidence:**
+src/c64Client.ts:268-275: the probe promise is stored per DeviceType and never invalidated; `.catch((error) => isMissingEndpoint(error) ? "unavailable" : "unknown")` bakes a transient network error into the cached value. `powerCycle` (980-990) hard-fails on anything but `"available"`.
+
+**Why production-reachable:**
+Platform status is the documented pre-flight read for physical input (AGENTS.md), and device boot/network blips are routine.
+
+**Why this degrades C64 control, development, or trust:**
+A supported high-value workflow (native input, tool-menu power cycle) is falsely disabled until the MCP server is restarted; agents are explicitly instructed to trust this resource.
+
+**Backend and recovery angle:** C64U only. No recovery path; restart required.
+
+**Relation to existing HARD01 findings:** Independent (capability caching, not menu logic).
+
+**Minimal fix sketch:** Do not cache `"unknown"` results — delete the map entry when the probe resolves to `"unknown"` so the next call retries.
+
+**Regression test strategy:** Unit test with a facade whose `getInputState` rejects with a network error once then succeeds; assert second `getNativeEndpointCapabilities` call reports `"available"`.
+
+**Fix risk:** Slightly more probe traffic on persistently failing devices; bounded by one GET per call.
+
+### HARD01-005 - Two divergent config loaders resolve different hosts for the same configuration files
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P2
+- **Dimensions:** config, backend-switching, documentation-contract
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/config.ts `loadConfig` (25-124), src/device.ts `readConfigFile` (179-214), src/mcp-server.ts (86-98), `createFacade` (1098-1162)
+
+**Failure scenario:**
+User sets `C64BRIDGE_CONFIG` to a file containing only `{ "vice": {...} }` while `~/.c64bridge.json` contains `{ "c64u": { "host": "10.0.0.5" } }`. `loadConfig` (src/config.ts) stops at the **first parseable file** (line 42-48 `break`), finds no hardware host, and yields the default baseUrl `http://c64u`. `readConfigFile` (src/device.ts) instead **merges sections across all candidate files** (lines 192-212), finds the home-file `c64u` section, and builds a c64u facade for `10.0.0.5`. Result: the startup connectivity probe, `client.baseUrl`-derived stream-capture host resolution (`new URL(this.baseUrl).hostname`, src/c64Client.ts:1299/1569), and the c64u facade all disagree about which device is the target. Additionally, malformed JSON crashes the server in `loadConfig` (rethrow at line 46) but is silently skipped by `readConfigFile` (bare `catch {}` line 211) — two different failure contracts for the same file.
+
+**Current-code evidence:** As above; the two functions also differ in HOME resolution (`process.env.HOME` only vs `HOME || os.homedir()`) and in `import.meta.url` handling (`fileURLToPath` vs raw `.pathname`, the latter broken for paths with spaces or on Windows).
+
+**Why production-reachable:**
+`C64BRIDGE_CONFIG` and layered config files are the documented configuration mechanism (AGENTS.md, README).
+
+**Why this degrades C64 control, development, or trust:**
+Stream capture targets (`resolveLocalCaptureAddress(host)` from `this.baseUrl`) and the actual REST facade can point at different machines; the startup "Connectivity check succeeded" log can validate a host that no tool will ever use — false confidence and wrong-target diagnostics.
+
+**Backend and recovery angle:** Affects c64u/u2 selection and the c64u video/audio capture address derivation; restart with aligned files required.
+
+**Relation to existing HARD01 findings:** Related to HARD01-006 (config path resolution) but distinct: this is loader-vs-loader divergence, 006 is documented-path vs actual-path.
+
+**Minimal fix sketch:** Make `C64Client`/`device.ts` consume the single parsed config from `loadConfig` (extended to carry sections), deleting `readConfigFile`.
+
+**Regression test strategy:** Unit test with two config files exercising both loaders and asserting identical host/port/password resolution.
+
+**Fix risk:** Precedence unification may change behaviour for users relying on the merge; document the chosen order.
+
+### HARD01-006 - Documented `./.c64bridge.json` lookup actually resolves relative to the installed package, not the working directory
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P2
+- **Dimensions:** config, documentation-contract, packaging
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/config.ts:31, src/device.ts:185, AGENTS.md "Configure target", README
+
+**Failure scenario:**
+A user installs c64bridge as a dependency (the documented VS Code MCP setup runs `node ./node_modules/c64bridge/dist/index.js` from the project root) and creates `./.c64bridge.json` in their project as AGENTS.md instructs ("`C64BRIDGE_CONFIG` → `./.c64bridge.json` → `~/.c64bridge.json` → defaults"). Both loaders resolve the "repo" candidate as `<module dir>/../.c64bridge.json` = `node_modules/c64bridge/.c64bridge.json`, so the project-local file is silently ignored. The server falls back to `~/.c64bridge.json` or default host `c64u` — potentially a *different, reachable* Ultimate device on the network — and tools operate on the wrong machine.
+
+**Current-code evidence:**
+src/config.ts:31 `join(dirname(fileURLToPath(import.meta.url)), "..", ".c64bridge.json")`; src/device.ts:185 same pattern. Neither consults `process.cwd()`.
+
+**Why production-reachable:** The npm-installed layout is the primary documented deployment (README/AGENTS VS Code snippet).
+
+**Why this degrades C64 control, development, or trust:**
+Silently targeting the default hostname `c64u` when a project config exists is a wrong-target risk for every state-changing tool (reset, config write, drive mount).
+
+**Backend and recovery angle:** All backends (vice section also ignored). Workaround is `C64BRIDGE_CONFIG`, but nothing tells the user their file was skipped.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-005 (path base vs loader divergence).
+
+**Minimal fix sketch:** Add `process.cwd()/.c64bridge.json` as a candidate (before or instead of the module-relative path) and log which file was loaded.
+
+**Regression test strategy:** Unit test running loadConfig with cwd fixture + module-relative absence, asserting cwd file wins; log assertion for chosen path.
+
+**Fix risk:** Changes resolution for dev checkouts where cwd ≠ repo root; keep module-relative candidate as fallback.
+
+### HARD01-007 - Printer text with double quotes generates invalid CBM BASIC (`""` doubling) that fails at runtime while the tool reports success
+
+- **Area:** Drives, storage, printers, streams, and state verification
+- **Severity:** P2
+- **Dimensions:** basic, program-runner, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `buildPrinterBasicProgram` (2421-2469), `escapeBasicQuotes` (2482-2485), `printTextOnPrinterAndRun` (331-339)
+
+**Failure scenario:**
+`c64_printer` print-text with content containing `"` (e.g. `He said "hi"`). `escapeBasicQuotes` doubles the quote, producing `PRINT#1,"HE SAID ""HI"""`. Commodore BASIC V2 has **no** doubled-quote escape — the expression evaluator sees adjacent string constants and raises `?SYNTAX ERROR` at runtime, aborting the program after `OPEN1,4` (printer channel left open). The MCP tool reports success because `uploadAndRunBasic` → `runPrg` only confirms upload/run start.
+
+**Current-code evidence:**
+src/c64Client.ts:2482-2485 with the comment "In Commodore BASIC, embed a double quote by doubling it" — true for some Microsoft BASIC dialects, false for CBM BASIC V2 (correct approach: `CHR$(34)`). Nothing downstream validates program completion.
+
+**Why production-reachable:** Any printer text containing a quote character; documented printer workflow (`.github/skills/printer-job`).
+
+**Why this degrades C64 control, development, or trust:**
+False success on a physical output job; machine left showing `?SYNTAX ERROR` with file 1 open (subsequent `OPEN1` fails with `FILE OPEN` until CLOSE/reset).
+
+**Backend and recovery angle:** All backends that run BASIC. Recovery needs manual CLOSE1/reset.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Replace embedded quotes by splicing `CHR$(34)` into the PRINT# expression (split chunk into quoted segments joined with `;CHR$(34);`).
+
+**Regression test strategy:** Tokenizer-level unit test that the generated program for quoted text contains no `""` sequence inside string literals; optional VICE screen assertion for `?SYNTAX ERROR` absence.
+
+**Fix risk:** Longer generated lines; keep chunking aware of the expansion.
+
+### HARD01-008 - PETSCII screen program's "wait for key" line never waits, so READY./cursor immediately disturb the rendered screen
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P3
+- **Dimensions:** basic, graphics, program-runner
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `buildPetsciiScreenBasic` (2407-2419), `renderPetsciiScreenAndRun` (408-415)
+
+**Failure scenario:**
+`renderPetsciiScreenAndRun` generates line `30 GETA$:IFA$<>""THENEND:REM wait for key then end`. `GET` is non-blocking and there is no loop back to 30: whether or not a key is pending, execution falls off the end of the program immediately. BASIC prints `READY.` and the blinking cursor onto the just-rendered artwork, and any subsequent `read_screen` verification sees `READY.` text that the caller did not draw.
+
+**Current-code evidence:** src/c64Client.ts:2416 — single GET with no `GOTO 30`; the comment states the (unimplemented) intent.
+
+**Why production-reachable:** PETSCII/graphics demo workflow (`.github/skills/graphics-demo`).
+
+**Why this degrades C64 control, development, or trust:** Rendered output is visually corrupted right after display; screen-content verification can mismatch, producing false negatives in demo validation.
+
+**Backend and recovery angle:** All backends.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** `30 GETA$:IFA$=""THEN30` (then `40 END`), or poke the cursor off and loop forever.
+
+**Regression test strategy:** Unit test on the generated source asserting the wait loop branches back; VICE screen capture shows no `READY.` after render.
+
+**Fix risk:** Program no longer terminates by itself; document that a key press ends it.
+
+### HARD01-009 - injectKeyboardQueue silently drops queued keystrokes when the KERNAL fails to drain, then reports plain success
+
+- **Area:** Ultimate REST, machine control, configuration, and input
+- **Severity:** P2
+- **Dimensions:** input, timeout-cancellation, memory-io
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `injectKeyboardQueue` (1900-1941)
+
+**Failure scenario:**
+`c64_input` `key`/`write_text` with more than 10 characters while the machine is paused, busy in a tight ML loop, or showing the Ultimate menu. The drain poll (lines 1932-1939) times out after 2 s with NDX ≠ 0; the loop then **continues to the next chunk anyway**, overwriting `$0277-$0280` with new bytes and forcing NDX to the new chunk length — destroying the unconsumed characters. The method returns `void` with no timeout indication, so every caller reports full text delivery while an arbitrary prefix/suffix of the text was lost or reordered.
+
+**Current-code evidence:**
+src/c64Client.ts:1929-1940. The comment says "higher layers can decide whether that is a failure" but no signal (return value, exception, flag) is produced for higher layers to decide with.
+
+**Why production-reachable:** `key`/`write_text` are the documented default input path whenever machine:input is unavailable (AGENTS.md); long strings are routine (`write_text` of a BASIC line is >10 chars).
+
+**Why this degrades C64 control, development, or trust:**
+Partial keystroke delivery with reported success corrupts typed programs/commands — e.g. a `RUN` or a POKE line typed half-way — and the agent trusts it happened.
+
+**Backend and recovery angle:** C64U/U64/VICE (shared memory path). No recovery; caller has no failure signal.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Return a result ({delivered, timedOut}) or throw on drain timeout; never overwrite a non-empty queue.
+
+**Regression test strategy:** Unit test with a facade whose NDX read never returns 0; assert an error/flag instead of silent return.
+
+**Fix risk:** Callers must handle the new failure signal; audit call sites.
+
+### HARD01-010 - Ultimate files endpoints double-encode device paths, encoding the path separators themselves
+
+- **Area:** Ultimate REST, machine control, configuration, and input
+- **Severity:** P2
+- **Dimensions:** c64u-rest, filesystem, tool-contract
+- **Confidence:** Medium
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/device.ts `filesInfo`/`filesCreateD64/71/81/Dnp` (380-384), generated/c64/index.ts `filesInfoDetail`/`filesCreateD64Update` (~1307-1340), doc/c64u/c64-openapi.yaml FilePath parameter (line 86)
+
+**Failure scenario:**
+`c64_disk create_d64` with `path: "/Usb0/demos/new.d64"`. `C64uBackend.filesCreateD64` calls `encodeURIComponent(p)` producing `%2FUsb0%2Fdemos%2Fnew.d64`; the generated client interpolates it verbatim, so the request line is `PUT /v1/files/%2FUsb0%2Fdemos%2Fnew.d64:create_d64`. The OpenAPI contract models the path as a filesystem path *below* `/v1/files/` with only reserved characters encoded ("Device filesystem path below `/v1/files/`; URL-encode reserved characters"), i.e. slashes remain literal separators (`/v1/files/Usb0/demos/new.d64:create_d64`). Firmware that routes on raw path segments will fail to resolve the target (or create a file with a literal `%2F` name), while the facade still returns `success:true` if the firmware answers 200 with an `errors` body (see HARD01-011).
+
+**Current-code evidence:** src/device.ts:380-384; generated client performs no additional decoding/encoding (`path: \`/v1/files/${path}${info}\``).
+
+**Why production-reachable:** All `c64_disk`/`c64_drive` create/info flows with nested device paths — the normal case, since Ultimate paths start with `/Usb0/...`.
+
+**Why this degrades C64 control, development, or trust:** Disk-image creation/inspection targeting the device filesystem silently misses or fails; the stated inference is that firmware treats `%2F` as an encoded literal rather than a separator, consistent with the spec's modelling of `{path}` as a slash-containing tail.
+
+**Backend and recovery angle:** c64u and u2 facades share the code.
+
+**Relation to existing HARD01 findings:** Interacts with HARD01-011 (error masking) but distinct root cause.
+
+**Minimal fix sketch:** Encode per-segment: `p.split("/").map(encodeURIComponent).join("/")`.
+
+**Regression test strategy:** Mock-Ultimate HTTP capture asserting the request path preserves `/` separators for a nested path with spaces.
+
+**Hardware validation:** One `files:info` call on a real C64U for a nested path.
+
+**Fix risk:** None beyond matching firmware expectations; verify against firmware once.
+
+### HARD01-011 - C64u/U2 facade reports success on any 2xx response, ignoring the firmware's `errors` array in ActionResponse bodies
+
+- **Area:** Ultimate REST, machine control, configuration, and input
+- **Severity:** P1
+- **Dimensions:** c64u-rest, tool-contract, config, drive
+- **Confidence:** Medium
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/device.ts `C64uBackend` (274-385, all `{ success: true, details: res.data }` returns), doc/c64u/c64-openapi.yaml (preamble lines 10-12, `ErrorList` 138-145, `ActionResponse` 252-256, `JsonOk` 501-506)
+
+**Failure scenario:**
+Any C64u/U2 REST action where firmware answers HTTP 200 but reports failures in the JSON body. The firmware contract (spec preamble) states "JSON responses include an `errors` array"; `ActionResponse` — the 200 body for every runner/machine/drive/config action — is `allOf: ErrorList` with required `errors`. Example: `configBatchUpdate` applying several items where some are rejected — firmware returns 200 with per-item error strings in `errors`; `C64uBackend.configBatchUpdate` (src/device.ts:376) returns `{ success: true }` and the MCP tool reports the whole batch applied. Same pattern on `runPrg`, `driveMount`, `sidplayFile`, etc.: every method returns `success: true` purely because axios didn't throw.
+
+**Current-code evidence:**
+All ~40 `C64uBackend` methods return `{ success: true, details: res.data }` with no inspection of `res.data.errors`. Stated inference (Medium confidence): the firmware does populate `errors` on 200 responses for partially-failed or soft-failed actions, which is exactly why the spec makes `errors` required on the success schema.
+
+**Why production-reachable:** Every Ultimate REST tool op flows through these methods.
+
+**Why this degrades C64 control, development, or trust:** Systemic false success on run/mount/config actions — the highest-value hardware operations — so agents proceed on unapplied state (e.g. believing a config batch or disk mount happened).
+
+**Backend and recovery angle:** c64u and u2. No recovery; verification tools (read-back) are the only mitigation and are not automatic.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-010 (path encoding); together they can turn a failed file create into a clean success.
+
+**Minimal fix sketch:** Central helper `ensureNoErrors(res.data)` that flips `success:false` (with the error strings in details) when `errors` is a non-empty array; apply in every C64uBackend method.
+
+**Regression test strategy:** Mock-Ultimate returning 200 + `{"errors":["Cannot open file"]}` for mount/run/config; assert tool result isError.
+
+**Hardware validation:** Optional: one deliberately failing `sidplayFile` with a bad path on real firmware to capture the actual status/body.
+
+**Fix risk:** If some firmware endpooints omit `errors`, treat absence as success (only non-empty array fails).
+
+### HARD01-012 - ViceClient has no response timeout; one lost Binary Monitor frame permanently wedges every later VICE operation
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P1
+- **Dimensions:** vice-monitor, timeout-cancellation, concurrency, vice-lifecycle
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/vice/viceClient.ts `send` (208-234), `onData` (150-206); src/device.ts `ViceBackend.withClient` (566-599), `monitorQueue` (403)
+
+**Failure scenario:**
+Any Binary Monitor command whose response is never delivered while the socket stays open: a resync in `onData` (line 156-158 skips to the next 0x02 byte, which can be mid-body, dropping a whole frame), a response consumed by the mismatch path without matching, or VICE simply not answering (busy UI dialog, monitor wedged). `send()` registers the pending promise with **no timeout**; `withClient`'s `fn` never resolves; the `finally` that releases `monitorQueue` never runs. Every subsequent VICE tool call awaits `previous` (line 573) forever. All VICE control — including `c64_select_backend`-independent flows like `read_screen` on the vice backend — hangs until the MCP server is restarted. The MCP request itself also never completes (hung request).
+
+**Current-code evidence:**
+src/vice/viceClient.ts:223-233 — promise stored in `this.pending`, resolved only by a matching frame, socket error, or close. src/device.ts:566-573 — strict FIFO promise chain with release only in `finally` after `fn` returns.
+
+**Why production-reachable:**
+The BM stream parser's resync heuristic (`this.buffer.indexOf(0x02, 1)`) can mis-frame on any body byte equal to 0x02 after a partial/corrupt read; display-get responses carry ~200KB of pixel data where 0x02 bytes are routine, so a single desync cascades. Independently, VICE can stall while holding the socket open.
+
+**Why this degrades C64 control, development, or trust:**
+One flaky exchange converts into a total, silent, permanent loss of the VICE backend and a hung MCP request — the worst recovery class short of protocol corruption.
+
+**Backend and recovery angle:** VICE only; restart of the MCP server is the only recovery. Backend switching cannot help because the switch tool works, but every VICE op still queues behind the wedged promise.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Per-request timeout (e.g. 10 s, longer for display) that rejects and deletes the pending entry; on timeout, destroy the socket so `withClient` cleanup runs and the queue releases.
+
+**Regression test strategy:** BM stub server that accepts a command and never responds; assert the client rejects within the timeout and a subsequent operation succeeds.
+
+**Fix risk:** Timeout must exceed slow legitimate operations (autostart, display on slow hosts).
+
+### HARD01-013 - Managed VICE and Xvfb processes are orphaned when the MCP server exits or is terminated
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P2
+- **Dimensions:** vice-lifecycle, filesystem, timeout-cancellation
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/device.ts `ensureCleanupRegistration` (552-564); src/vice/process.ts `stop` (389-405), `terminateProcess` (209-214)
+
+**Failure scenario:**
+(a) Normal exit: the only cleanup hook is `process.once("exit", ...)` which calls the async `handle.stop()`. Inside an `exit` handler the event loop never turns again, so only the *synchronous prefix* of `stop()` runs: the first `child.kill("SIGTERM")`. The `await waitForExit(...)` never resolves, so the SIGKILL escalation and — critically — **all Xvfb termination lines never execute**. Every headless/managed session leaks one Xvfb process (and VICE too if it ignores SIGTERM).
+(b) Signal termination: no SIGTERM/SIGINT/SIGHUP handlers exist anywhere; when the MCP client (VS Code, Claude) kills the server — the normal lifecycle for stdio MCP servers — Node's default signal handling terminates the process without emitting `exit`, so **no cleanup at all** runs: both VICE and Xvfb are orphaned, still bound to the BM port and X display.
+
+**Current-code evidence:** As cited; `rg -n "process.on(\"SIG" src` returns nothing.
+
+**Why production-reachable:** Managed VICE is the default for local hosts (device.ts:429), Xvfb is the default when no display exists (process.ts:88-98); MCP servers are routinely killed by their client.
+
+**Why this degrades C64 control, development, or trust:**
+Orphaned VICE keeps the monitor port occupied; the *next* server session's `tryPingExisting` then adopts a stale emulator with unknown state (loaded programs, checkpoints), and repeated sessions accumulate Xvfb processes and X lock files (`/tmp/.X99-lock`), eventually exhausting the display-number scan.
+
+**Backend and recovery angle:** VICE managed mode. Recovery: manual pkill.
+
+**Relation to existing HARD01 findings:** Independent of HARD01-012 (protocol vs lifecycle).
+
+**Minimal fix sketch:** Install SIGTERM/SIGINT handlers that synchronously `kill()` VICE and Xvfb (child.kill is sync) then `process.exit`; in the `exit` hook, call the sync kills directly instead of the async stop().
+
+**Regression test strategy:** Spawn-mock test asserting registered signal handlers issue kills for both PIDs; integration check that no Xvfb survives server SIGTERM.
+
+**Fix risk:** Double-kill on already-exited children (guarded by exitCode checks).
+
+### HARD01-014 - c64_input joystick on VICE writes CIA data-port registers, which cannot simulate joystick input; success is reported for a no-op
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P1
+- **Dimensions:** input, vice-monitor, tool-contract, memory-io
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/input.ts joystick handler (351-407), JOYSTICK_PORT_ADDRESS (122-125); src/vice/viceClient.ts (no Joyport implementation); doc/vice/vice-binary-monitor-spec.md §0xA2 Joyport Set
+
+**Failure scenario:**
+`c64_input` `{op:"joystick", port:2, controls:["right"], action:"tap"}` on the VICE backend. The handler writes `$DC00` (port 2) / `$DC01` (port 1) via BM `memSet`. On a C64 (and in VICE's CIA emulation), `$DC00/$DC01` reads return the *input line state* for bits configured as inputs — writing the port register only sets the output latch (DDR for port B is $00 after reset, so writes are fully invisible to reads; for port A, DDR is $FF and the write actively corrupts the keyboard-scan column selection until the next KERNAL IRQ rewrite). A game polling the joystick sees nothing; the tool reports "Joystick port 2 tapped: right" with `success: true`.
+
+**Current-code evidence:**
+src/tools/input.ts:373-401 uses `ctx.client.viceMemSet(addr, ...)`. The in-repo BM spec documents the correct mechanism — command `0xA2 Joyport Set` ("Delegates to `mon_joyport_set_output`") — which `src/vice/viceClient.ts` does not implement at all.
+
+**Why production-reachable:** `joystick` op is gated to `["c64u","vice"]` (input.ts:483) and documented ("VICE writes CIA1 registers", workflowHints line 465), so agents will use it for game control on VICE.
+
+**Why this degrades C64 control, development, or trust:**
+Every VICE joystick interaction is a false success; agents testing games conclude the game ignores input or burn cycles retrying. The port-2 write also transiently disturbs keyboard scanning.
+
+**Backend and recovery angle:** VICE only; c64u path uses machine:input correctly.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Implement BM `0xA2 Joyport Set` in ViceClient and use it for press/release/tap (value bitmask per VICE joyport semantics).
+
+**Regression test strategy:** BM stub asserting an 0xA2 command with the expected port/value; optional HIL-style VICE test reading `$DC00` after joyport set.
+
+**Hardware validation:** Managed VICE with a joystick-polling test program.
+
+**Fix risk:** Joyport value encoding must match VICE's expectations (active-low bitmask).
+
+### HARD01-015 - checkpointCreate silently adds the execute flag to load/store-only watchpoints
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P3
+- **Dimensions:** vice-monitor, tool-contract, 6510
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/vice/viceClient.ts `checkpointCreate` (287-309); src/tools/debug.ts checkpoint_set handler (339)
+
+**Failure scenario:**
+`c64_debug` checkpoint create with `operations: { store: true }` (a store watchpoint on a data address). Line 293: `mask = (load?1:0)|(store?2:0)|(ops.execute === false ? 0 : 0x04)` — because `execute` is `undefined`, the exec bit is set too. If the watched address is ever executed (self-modifying code, data mistaken for code after a crash, or a watch on a code address intended as store-only), VICE stops on execution the user never asked to trap, leaving the machine halted in the monitor and confusing the debugging session.
+
+**Current-code evidence:** As cited; the default only applies when `operations` is absent, but the expression applies it whenever `execute` isn't explicitly `false`.
+
+**Why production-reachable:** `checkpoint_set` accepts partial operations objects from the MCP schema.
+
+**Why this degrades C64 control, development, or trust:** Spurious traps freeze the emulated machine mid-workflow and misattribute behaviour during debugging.
+
+**Backend and recovery angle:** VICE only; recovered by deleting the checkpoint.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** `const mask = (ops.load?1:0)|(ops.store?2:0)|(ops.execute?4:0) || 4` — exec only when requested, defaulting to exec solely when no operation flag at all is given.
+
+**Regression test strategy:** Unit test asserting the wire mask for `{store:true}` is exactly 0x02.
+
+**Fix risk:** Callers relying on the accidental exec default; audit debug.ts.
+
+### HARD01-016 - Platform gating and multi-step client flows race with c64_select_backend, allowing operations to land on the wrong target
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P2
+- **Dimensions:** backend-switching, concurrency, capability, device-safety
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/types.ts `invoke` (377-407); src/c64Client.ts `switchBackend` (304-316); src/tools/registry/platform.ts select handler (79-113); src/tools/memory.ts `executeWriteMemory` (268-445)
+
+**Failure scenario:**
+MCP clients issue tool calls concurrently (nothing serializes CallTool handlers). Request A (`c64_memory` write with verify, active backend vice) passes the platform gate against the platform snapshot, then performs `pause → pre-read → write → post-read` as **separate `ctx.client` calls, each awaiting `this.facadePromise` independently**. Request B (`c64_select_backend {backend:"c64u"}`) runs between A's steps: `switchBackend` swaps `facadePromise` immediately. A's remaining steps now execute against **real C64U hardware** — a write intended for the emulator lands on the physical machine, and the post-read verifies the wrong device (false verification either way). The same window exists inside the select handler itself: between `switchBackend` (line 97) and `setPlatform` (line 98), concurrent requests are gated against the old platform while routed to the new backend.
+
+**Current-code evidence:** As cited. No lock, generation counter, or in-flight-drain exists around `switchBackend`; `C64Client` methods re-resolve `facadePromise` per call (e.g. c64Client.ts:721, 779, 837).
+
+**Why production-reachable:** Runtime backend switching is a headline feature (AGENTS.md "Runtime Backend Switching"); concurrent MCP calls are normal for agent clients that parallelise tool use.
+
+**Why this degrades C64 control, development, or trust:** Wrong-target memory/system writes are a physical-state hazard; verification results become untrustworthy exactly when the user is exercising the documented multi-backend workflow.
+
+**Backend and recovery angle:** All backends. No detection or recovery; the misdirected write is silent.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-004/005 (static config/capability); this is dynamic switch-vs-in-flight consistency.
+
+**Minimal fix sketch:** Capture the facade once per tool invocation (pass it through ctx), or add a read-write lock: switches wait for in-flight operations to drain and new operations pin the facade they started with.
+
+**Regression test strategy:** Concurrency test with mock facades: start a slow write-verify, switch backend mid-flight, assert all steps hit the original facade.
+
+**Fix risk:** Locking must not deadlock long-running ops (streams, background tasks); pinning per-invocation is safer.
+
+### HARD01-017 - Memory write verification leaves the machine paused (with success reported) when resume fails
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P2
+- **Dimensions:** memory-io, physical-state, timeout-cancellation
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/memory.ts `executeWriteMemory` finally block (420-438)
+
+**Failure scenario:**
+`c64_memory` write with `verify: true` on C64U/U2. Pause and verification succeed; the trailing `ctx.client.resume()` fails (transient REST timeout, firmware hiccup). The failure is only logged via `ctx.logger.warn` to stderr; the tool returns the already-built success result ("Wrote N bytes ... (verified)"). The physical machine stays DMA-paused — frozen screen, unresponsive — and neither the agent nor the user is told. Subsequent screen reads/waits poll a frozen machine and time out mysteriously.
+
+**Current-code evidence:** src/tools/memory.ts:420-438 — `finally` swallows both the unsuccessful `resumeResult` and thrown resume errors; the success return from line 410 stands.
+
+**Why production-reachable:** verify is the documented safe-write mode; REST calls to hardware can transiently fail.
+
+**Why this degrades C64 control, development, or trust:** A "verified success" that leaves hardware frozen is a false-success with physical consequence; the failure surfaces later in unrelated tools.
+
+**Backend and recovery angle:** C64U/U2 (vice skips pause). Recovery requires an explicit `c64_system resume`.
+
+**Relation to existing HARD01 findings:** Independent of HARD01-016 (no switch involved).
+
+**Minimal fix sketch:** On resume failure, degrade the result: keep write status but set `success: false`/`machinePaused: true` with instructions to call resume, or retry resume once.
+
+**Regression test strategy:** Mock client with failing resume; assert result flags the paused state.
+
+**Fix risk:** Minor result-shape change for callers.
+
+### HARD01-018 - upload_run_asm produces PRGs with no BASIC/SYS entry mechanism, so pure machine-code programs never execute yet report success
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P1
+- **Dimensions:** program-runner, 6510, tool-contract, basic
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/translation/assembler.ts (`assemblyToPrgDetailed` 196-215, `buildPrg` 870-880, header comment line 16), src/tools/programRunners.ts `executeUploadRunAsm` (565-640, including the tool's own example at 835-838), src/device.ts `ViceBackend.injectPrg` (625-643), C64uBackend.runPrg (274-278)
+
+**Failure scenario:**
+`c64_program` `{op:"upload_run_asm", program:".org $0801\nstart: lda #$01\n sta $0400\n rts"}` — the tool's own published example. The assembler emits raw opcodes at $0801 with **no BASIC stub** (no stub-generation code exists anywhere; the file-header comment "can be run with SYS 2061" describes an intent that was never implemented, and nothing ever issues a SYS). Both execution paths then LOAD + type `RUN`: Ultimate `:run_prg` firmware behaviour, and `ViceBackend.injectPrg` which sets the BASIC pointers and feeds `RUN\r`. `RUN` interprets the ML bytes at $0801 as BASIC line links — the machine code never executes. For sources org'd elsewhere (`.org $C000`), `injectPrg` additionally sets TXTTAB/VARTAB to $C000, corrupting the BASIC workspace. The tool reports "Assembly program assembled, uploaded, and executed successfully", optionally with `verified: true` (see HARD01-019 for why polling cannot catch this).
+
+**Current-code evidence:** As cited; `rg -n "2061|stub"` over src/tools/translation and programRunners matches only the comment.
+
+**Why production-reachable:** upload_run_asm is a core documented workflow (`.github/skills/assembly-program`), and the failing input is the tool's own example.
+
+**Why this degrades C64 control, development, or trust:** The flagship assembly workflow is a systematic false success; users iterate on 6510 code that never runs.
+
+**Backend and recovery angle:** Both C64U/U2 and VICE. VICE additionally leaves corrupted BASIC pointers for non-$0801 loads until reset.
+
+**Relation to existing HARD01 findings:** HARD01-019 explains why the "verified" layer masks this; distinct root causes (missing entry mechanism vs dead crash-detection).
+
+**Minimal fix sketch:** When loadAddress ≤ $0801 emit the standard 12-byte `10 SYS<entry>` stub before code (adjusting org), or after load inject `SYS <entry>` instead of `RUN`; on VICE, only set BASIC pointers for genuine BASIC PRGs.
+
+**Regression test strategy:** VICE integration test asserting `$0400` receives `$01` after running the example source; unit test asserting the emitted PRG starts with a valid BASIC line ending in a SYS to the first instruction.
+
+**Hardware validation:** One run on C64U with a border-colour-writing ML program.
+
+**Fix risk:** Stub insertion shifts code addresses; must keep symbols/entryAddress consistent.
+
+### HARD01-019 - ASM crash detection can never fire: the activity signature includes the VIC raster register, so every powered-on machine is "alive"
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P2
+- **Dimensions:** program-runner, memory-io, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/pollValidator.ts `pollAsmOutcome` (214-336)
+
+**Failure scenario:**
+`pollAsmOutcome` computes a CRC over `$D000-$DFFF` plus low memory each poll and declares the program "alive" when consecutive CRCs differ. `$D012` (VIC raster counter) is inside that range and changes on essentially every read, as do CIA timer registers ($DC04-$DC07 count continuously) — so the signature differs on every pair of polls on any powered-on machine, running or crashed. `alive` is set on the second sample unconditionally; the `"crashed"` branch is dead code in practice. Consequently `verified: true` from `upload_run_asm` (programRunners.ts:592-604) asserts nothing, and a genuinely crashed/never-executed program (HARD01-018) is reported as verified success. The jiffy-clock secondary check has the same property (jiffy advances at the READY prompt).
+
+**Current-code evidence:** src/tools/pollValidator.ts:275 (`readMemoryRaw(0xD000, 0x1000)`), 288-299 (signature comparison), no masking of free-running registers.
+
+**Why production-reachable:** Runs on every `upload_run_asm` call.
+
+**Why this degrades C64 control, development, or trust:** A promised verification layer that cannot fail converts every ASM failure into "verified" success.
+
+**Backend and recovery angle:** Both backends (VICE displays the same free-running registers).
+
+**Relation to existing HARD01 findings:** Masks HARD01-018; distinct defect.
+
+**Minimal fix sketch:** Exclude free-running registers ($D011/$D012, CIA timers/TOD) from the signature, or verify a program-specific effect (entry-point PC via VICE, or explicit screen/memory expectations).
+
+**Regression test strategy:** Unit test with a mock client returning identical memory except an incrementing $D012; assert status is "crashed".
+
+**Fix risk:** Overly strict masking could false-crash IRQ-driven programs; document the heuristic.
+
+### HARD01-020 - ASM outcome polling DMA-reads the CIA interrupt-control registers on hardware, clearing pending IRQs in the just-started program
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P2
+- **Dimensions:** memory-io, device-safety, c64u-rest, program-runner
+- **Confidence:** Medium
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/pollValidator.ts:275; src/device.ts `C64uBackend.readMemory` (301-316); c64://io/cia/spec knowledge (CIA ICR semantics)
+
+**Failure scenario:**
+Every `upload_run_asm` triggers repeated reads of `$D000-$DFFF`, which includes `$DC0D` and `$DD0D` (CIA1/CIA2 interrupt control registers). On real hardware, reading the ICR **clears all pending interrupt flags** — this is fundamental CIA behaviour. The Ultimate's `:readmem` performs genuine DMA bus reads, so a program that has just installed a CIA-timer IRQ (music player, raster/timer mixing, tape/serial timing) can lose interrupts each poll cycle (default 200 ms interval for the 2 s window), causing missed IRQs, audio glitches, or a hung IRQ-wait loop right after upload — precisely while the tool is judging whether the program is alive. Stated inference (Medium): Ultimate DMA reads are electrically real reads and therefore trigger CIA read side effects; this matches the platform's own memory-debug guidance to avoid I/O reads without pause. VICE is unaffected because `memGet` is sent with `sidefx=0`.
+
+**Current-code evidence:** As cited; no exclusion of the I/O page or pause around the polling reads.
+
+**Why production-reachable:** Automatic on every hardware ASM upload.
+
+**Why this degrades C64 control, development, or trust:** The validator itself can break the program it validates — a Heisenberg failure users cannot diagnose.
+
+**Backend and recovery angle:** C64U/U64 (and U2 path) only.
+
+**Relation to existing HARD01 findings:** Same function as HARD01-019, independent defect (side effect vs dead logic).
+
+**Minimal fix sketch:** Read only side-effect-free regions (screen RAM, jiffy via $A0-$A2, selected VIC colour registers), never $DC00-$DD0F.
+
+**Regression test strategy:** Mock-Ultimate asserting no read overlapping $DC0D/$DD0D during polling; HIL check with an IRQ-counting program.
+
+**Hardware validation:** C64U with a CIA-timer IRQ program comparing IRQ counts with/without polling.
+
+**Fix risk:** None significant.
+
+### HARD01-021 - BASIC outcome polling reports failure whenever the program legitimately prints the word "ERROR"
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P3
+- **Dimensions:** basic, program-runner, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/pollValidator.ts `extractBasicError` (121-145), `pollBasicOutcome` (151-206); src/tools/programRunners.ts BASIC error handling
+
+**Failure scenario:**
+`upload_run_basic` with a program whose *output or source strings* contain "ERROR" (e.g. a validation utility printing `0 ERRORS FOUND`, or a game HUD). `extractBasicError` matches any screen containing "ERROR"; without the `?TYPE ERROR` pattern it returns `{message:"UNKNOWN ERROR"}`, so `pollBasicOutcome` reports `status:"error"` and the tool returns a failure for a program that ran perfectly. The inverse hazard also exists: real errors printed after the 2 s window (slow init loops) are missed and success is reported — but the false-failure direction is deterministic for the described programs.
+
+**Current-code evidence:** src/tools/pollValidator.ts:125-144 (bare `includes("ERROR")` fallback path returning UNKNOWN ERROR).
+
+**Why production-reachable:** Ordinary user programs printing status text.
+
+**Why this degrades C64 control, development, or trust:** Deterministic false failure on a supported workflow teaches users to distrust tool errors.
+
+**Backend and recovery angle:** All backends.
+
+**Relation to existing HARD01 findings:** Same file as 019/020 but a distinct heuristic and direction.
+
+**Minimal fix sketch:** Require the leading `?` (BASIC's error prefix at column start) and known KERNAL/BASIC error names before classifying as an error.
+
+**Regression test strategy:** Unit test with screens containing "0 ERRORS FOUND" (ok) and "?SYNTAX  ERROR IN 20" (error).
+
+**Fix risk:** Slightly weaker detection of exotic error strings.
+
+### HARD01-022 - Persisted "running" background tasks are never rescheduled after restart, so list_tasks reports live tasks that do nothing
+
+- **Area:** Background tasks, meta workflows, artifacts, and cancellation
+- **Severity:** P2
+- **Dimensions:** background-task, persistence, tool-contract
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/meta/background.ts `ensureTasksLoaded` (128-147), `fromPersistedTask` (83-102), `scheduleNextRun` (228-258), `list_background_tasks` (382-412)
+
+**Failure scenario:**
+A background task (e.g. recurring `read_screen`) is started; state is persisted with `status:"running"`. The MCP server restarts (routine for stdio servers). On the next task tool call, `ensureTasksLoaded` reads `tasks.json` and rebuilds each task with `_timer:null` — but **never calls `scheduleNextRun`**. The task is now a zombie: `list_tasks` reports it `status:"running"` with a stale `nextRunAt`, yet no timer exists and it will never fire again. `stop_all_background_tasks` then marks it "stopped" as if it had been running.
+
+**Current-code evidence:** src/tools/meta/background.ts:83-102 (`_timer:null`, no scheduling); 128-147 (`ensureTasksLoaded` only populates the map). No code path re-arms persisted running tasks.
+
+**Why production-reachable:** Task persistence is the tool's entire purpose (`getTaskStateFilePath`, per-task folders); server restarts are normal.
+
+**Why this degrades C64 control, development, or trust:** `list_tasks` is a false status source — the agent believes recurring diagnostics are running when they are dead; downstream decisions (e.g. "monitoring is active, safe to proceed") are wrong.
+
+**Backend and recovery angle:** Backend-independent. Recovery: stop and restart each task manually.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** In `ensureTasksLoaded`, for each task loaded with `status:"running"`, either re-arm via `scheduleNextRun` (needs a ctx) or downgrade to `"stopped"`/`"interrupted"` so status is honest.
+
+**Regression test strategy:** Unit test: persist a running task, reset module state, reload, assert either a timer is armed or status is not "running".
+
+**Fix risk:** Re-arming needs a client/ctx not available at load time; the honest-downgrade path is safer.
+
+### HARD01-023 - drive_mount_and_verify assumes the VICE drive shape, so power-on and verification silently fail on C64U/U2 hardware
+
+- **Area:** Drives, storage, printers, streams, and state verification
+- **Severity:** P2
+- **Dimensions:** drive, c64u-rest, u2-variant, tool-contract
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/meta/filesystem.ts `drive_mount_and_verify` (690-799); src/device.ts `C64uBackend.drivesList` (363) vs `ViceBackend.drivesList` (806-826); doc/c64u/c64-openapi.yaml `DriveListResponse`/`DriveInfo` (284-295, 257-277)
+
+**Failure scenario:**
+`drive_mount_and_verify` on C64U/U2. `C64uBackend.drivesList` returns the firmware body verbatim: `{ errors, drives: [ { "<driveId>": { enabled, image_file, image_path, type, ... } } ] }` — an **object with a `.drives` array of id-keyed maps**. The meta tool does `Array.isArray(drives)` on that object (false), so `targetDrive` is `null`, and with `powerOnIfNeeded` (default true) it throws "Drive not found in firmware drive list" — the mount never happens. Even bypassing power-on, the verify step reads `targetDrive.image`/`.power`, fields that exist only on the **VICE** facade's synthetic `{id, power, image, type}` shape (device.ts:814-819). The tool therefore works only on VICE and hard-fails on real hardware, which is its primary target.
+
+**Current-code evidence:** As cited; `storageModule.drives_list` also returns the raw c64u object untouched (storage.ts:207-211), so the two facades expose different drive schemas with no normalisation layer.
+
+**Why production-reachable:** `c64_disk`/drive management on hardware is a core documented workflow.
+
+**Why this degrades C64 control, development, or trust:** A reliability-branded mount tool (retries + verification) is unusable on the very platform it targets, failing before it mounts.
+
+**Backend and recovery angle:** C64U/U2 broken; VICE works. Users must fall back to the lower-level `drive_mount`.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-011 (errors-array) — this is drive-list schema divergence.
+
+**Minimal fix sketch:** Add a facade-level `drivesList` normaliser returning a common `{id, power, image, type}` shape for all backends; have meta/storage consume that.
+
+**Regression test strategy:** Mock-Ultimate returning the real DriveListResponse shape; assert drive_mount_and_verify locates the drive and verifies image_path.
+
+**Hardware validation:** C64U `drives_list` capture to confirm exact field names.
+
+**Fix risk:** Field mapping (`image_path` vs `image`, `enabled` vs `power`) must match firmware.
+
+### HARD01-024 - Debug-level HTTP logging writes the raw X-Password header to stderr and the diagnostics file
+
+- **Area:** RAG, external acquisition, paths, diagnostics, and secrets
+- **Severity:** P3
+- **Dimensions:** secrets, diagnostics, security
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/loggingHttpClient.ts `handleResponse`/`handleError` (59-64, 90-95, meta.headers capture at ~28); src/device.ts `buildC64uHeaders` (1373-1375); src/c64Client.ts constructor headers (205)
+
+**Failure scenario:**
+The MCP server is run with `LOG_LEVEL=debug` (a documented troubleshooting step). Every Ultimate REST request logs `request <method> <path>` with `headers: meta.headers`, and `meta.headers` is a shallow copy of the axios request headers **including `X-Password: <networkPassword>`** in cleartext. These lines go to stderr and, via the diagnostics event stream, potentially to the on-disk diagnostics file — exposing the device network password to anyone who can read the logs.
+
+**Current-code evidence:** src/loggingHttpClient.ts:28 (`headers: request.headers ? { ...request.headers } : undefined`) and 60-62/90-92 log those headers unredacted. No key-based redaction exists (`rg -n "redact|X-Password" src/logger.ts src/loggingHttpClient.ts` finds none).
+
+**Why production-reachable:** Debug logging is the standard way to diagnose REST issues; network protection with a password is the documented secure configuration.
+
+**Why this degrades C64 control, development, or trust:** Secret disclosure through diagnostics — the review's explicit "do not disclose X-Password" concern realised in the product's own logs.
+
+**Backend and recovery angle:** C64U/U2 (password auth). VICE unaffected.
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Redact sensitive header keys (`x-password`, `authorization`) before logging, replacing values with `***`.
+
+**Regression test strategy:** Unit test capturing debug output for a request with X-Password; assert the value is masked.
+
+**Fix risk:** None; redaction is display-only.
+
+### HARD01-025 - RAG initialization resolves all knowledge paths from process.cwd(), so the packaged server returns empty retrievals when started elsewhere
+
+- **Area:** RAG, external acquisition, paths, diagnostics, and secrets
+- **Severity:** P2
+- **Dimensions:** rag, filesystem, packaging
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/rag/init.ts (module-level `path.resolve("external"|"data/..."|"doc"|"AGENTS.md"|".github/prompts")` lines 13-21, `resolveEmbeddingsDir` 23-24), `loadIndexes` (src/rag/indexer.ts 865-885, best-effort try/catch)
+
+**Failure scenario:**
+The documented VS Code MCP config launches `node ./node_modules/c64bridge/dist/index.js` with the user's **project** as cwd. Every RAG path is `path.resolve("data/...")` = `<project>/data/...`, not the package's bundled `data/`. `loadIndexes` wraps each read in `try {} catch {}`, so all embedding files are missing → the retriever loads with empty indexes and returns no snippets. `c64_rag` and every prompt/resource enrichment silently yields nothing; the failure is swallowed (no throw), so the agent gets empty knowledge with no error.
+
+**Current-code evidence:** src/rag/init.ts:13-21 use bare `path.resolve(...)` (cwd-relative); indexer's `loadIndexes` silently ignores read failures.
+
+**Why production-reachable:** npm-installed usage with project cwd is the primary deployment (package.json ships `data/**`, `doc/**` precisely so the server can read them from the package dir).
+
+**Why this degrades C64 control, development, or trust:** The RAG/knowledge subsystem — a headline capability — is silently empty for installed users, degrading BASIC/ASM assistance with no diagnostic.
+
+**Backend and recovery angle:** Backend-independent. Workaround: run with cwd = package root, undocumented.
+
+**Relation to existing HARD01 findings:** Same cwd-vs-package root theme as HARD01-006 (config); distinct subsystem and impact.
+
+**Minimal fix sketch:** Resolve knowledge/data/doc paths relative to the module (`fileURLToPath(import.meta.url)` + package root), with cwd as an optional override.
+
+**Regression test strategy:** Run initRag from a temp cwd and assert indexes still load from the package data dir.
+
+**Fix risk:** Dev checkouts that rely on cwd must still work; keep an env override.
+
+### HARD01-026 - VICE reset() reports success even when BASIC never reaches the READY prompt
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P2
+- **Dimensions:** vice-lifecycle, program-runner, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/device.ts `ViceBackend.reset` (697-713); src/vice/readiness.ts `waitForBasicReady` (120-166)
+
+**Failure scenario:**
+`c64_system reset` (or `reboot`, which delegates to reset) on VICE. `reset()` calls `waitForBasicReady` and captures its `{pointersOk, promptOk}` result but **ignores both flags**, then returns `{ success: true }` unconditionally. If the machine never reached a usable BASIC prompt within 20 s (stuck autostart, prior crash, monitor desync), the tool still reports a clean reset. The very next `upload_run_basic`/`injectPrg` (which only does a best-effort `waitForBasicReady`) then types into a machine that is not at READY, silently losing the program.
+
+**Current-code evidence:** src/device.ts:709-712 — `readiness` is read and only logged under debug; success is hardcoded. Contrast `ViceBackend.ensureProcessInternal` (477-491) which *does* throw when readiness fails.
+
+**Why production-reachable:** reset/reboot are core ops used before every program run.
+
+**Why this degrades C64 control, development, or trust:** False "reset succeeded" hides a wedged emulator, cascading into silent program-run failures.
+
+**Backend and recovery angle:** VICE only. C64U/U2 resets are fire-and-forget firmware calls.
+
+**Relation to existing HARD01 findings:** Independent of HARD01-012 (timeout) though both concern VICE readiness.
+
+**Minimal fix sketch:** Return `{ success: readiness.pointersOk && readiness.promptOk, details: readiness }` so callers see the failure.
+
+**Regression test strategy:** BM stub where pointers never settle; assert reset returns success:false.
+
+**Fix risk:** Callers currently assuming success:true on VICE reset must handle failure.
+
+### HARD01-027 - Config resolution reads C64BRIDGE_CONFIG as JSON but throws the whole server on any non-ENOENT error (malformed JSON, EACCES)
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P3
+- **Dimensions:** config, packaging, diagnostics
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/config.ts `loadConfig` (36-49); src/mcp-server.ts `main` load_config span (86)
+
+**Failure scenario:**
+A user's `~/.c64bridge.json` (or `C64BRIDGE_CONFIG` file) contains a trailing comma or is not readable (permissions). In `loadConfig`, `JSON.parse(readFileSync(...))` throws `SyntaxError` (or an `EACCES` error); the loop rethrows anything that is not `ENOENT` (line 45-47). `loadConfig` is called synchronously in `main` before the transport connects, so the process exits with a fatal error and the MCP server never starts — with a raw parse error rather than actionable guidance. `device.ts`'s parallel `readConfigFile` swallows the same error (bare `catch {}`), so the two loaders disagree on whether a bad file is fatal.
+
+**Current-code evidence:** src/config.ts:44-48 rethrow on non-ENOENT; src/device.ts:211 `catch {}`.
+
+**Why production-reachable:** Hand-edited JSON config with a syntax slip is common.
+
+**Why this degrades C64 control, development, or trust:** A one-character config typo takes the whole server down at startup with an opaque error, instead of falling back to defaults with a warning.
+
+**Backend and recovery angle:** All backends; server won't boot.
+
+**Relation to existing HARD01 findings:** Related to HARD01-005/006 (config loaders) but distinct: this is the fatal-on-malformed behaviour and its inconsistency with device.ts.
+
+**Minimal fix sketch:** Catch parse/read errors, log a clear warning, and continue with defaults (matching device.ts leniency), or fail fast in both loaders consistently.
+
+**Regression test strategy:** Unit test: malformed JSON at C64BRIDGE_CONFIG; assert loadConfig returns defaults with a warning rather than throwing.
+
+**Fix risk:** Silent fallback could mask a real misconfiguration; emit a prominent warning.
+
+### HARD01-028 - Background task iterations that return `{success:false}` are counted as successful; only thrown errors are recorded
+
+- **Area:** Background tasks, meta workflows, artifacts, and cancellation
+- **Severity:** P3
+- **Dimensions:** background-task, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/meta/background.ts `scheduleNextRun` (232-257), `runOperation` (205-226)
+
+**Failure scenario:**
+A background task runs `read`/`write`/`menu_button`, whose `C64Client` methods **return** `{ success:false, details }` on failure rather than throwing (client swallows errors into normaliseError). `scheduleNextRun` awaits `runOperation`, then unconditionally increments `iterations`, logs `iteration=N`, and reschedules — never inspecting `.success`. A task pointed at an unreachable device or wrong backend logs a growing "healthy" iteration count while every iteration actually failed; `lastError` stays null.
+
+**Current-code evidence:** src/tools/meta/background.ts:235-247 — no check of the resolved value's `success`.
+
+**Why production-reachable:** Any background monitor against a device that intermittently fails.
+
+**Why this degrades C64 control, development, or trust:** Task status/iteration count is a false health signal; failing monitors look healthy.
+
+**Backend and recovery angle:** All backends.
+
+**Relation to existing HARD01 findings:** Same file as HARD01-022, distinct defect (success accounting vs reschedule-on-restart).
+
+**Minimal fix sketch:** Inspect the resolved result's `success`; on false, set `lastError` and optionally `status:"error"` or a failure counter.
+
+**Regression test strategy:** Unit test with a client returning `{success:false}`; assert the task records the failure.
+
+**Fix risk:** Deciding stop-vs-continue policy; make it configurable, default to recording without stopping.
+
+### HARD01-029 - bundle_run_artifacts writes files outside the requested output directory via an unsanitised runId (path traversal)
+
+- **Area:** Background tasks, meta workflows, artifacts, and cancellation
+- **Severity:** P2
+- **Dimensions:** filesystem, security, background-task
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/meta/artifacts.ts `bundle_run_artifacts` (30-104), `bundleRunArtifactsArgsSchema` (9-28)
+
+**Failure scenario:**
+`c64_program bundle_run` / `bundle_run_artifacts` with `{runId:"../../../../home/chris/.config/evil", outputPath:"/tmp/artifacts"}`. `runId` is validated only as `minLength:1` (no character/`..` restriction). `resolvePath(joinPath(outputPath, runId))` normalises the `..` segments and escapes `/tmp/artifacts` entirely; the tool then `fs.mkdir(runPath, {recursive:true})` and writes `screen.txt`, `memory/range_*.hex`, `debugreg.json`, and `manifest.json` into the attacker/agent-chosen location, creating directories and overwriting files anywhere the process can write.
+
+**Current-code evidence:** src/tools/meta/artifacts.ts:47-54 (runId joined and resolved without containment check); schema line 12 (no pattern). The memory filename also interpolates `range.address` unsanitised (line 74).
+
+**Why production-reachable:** `bundle_run` is a documented program-orchestration op; runId is free-form text an LLM composes from user input.
+
+**Why this degrades C64 control, development, or trust:** Arbitrary file/directory creation and overwrite outside the intended artifacts tree — a filesystem-integrity/security defect in an automated agent context.
+
+**Backend and recovery angle:** Backend-independent (host filesystem).
+
+**Relation to existing HARD01 findings:** Independent; complements HARD01-025/006 (path handling) but this is an escape from a user-supplied base, not a base-resolution bug.
+
+**Minimal fix sketch:** Reject runId containing path separators or `..` (or slugify it), and after resolving assert `runPath` is contained within `outputPath` (`runPath.startsWith(outputPath + sep)`).
+
+**Regression test strategy:** Unit test with `runId:"../escape"`; assert the tool errors and writes nothing outside outputPath.
+
+**Fix risk:** None; tighter validation only.
+
+### HARD01-030 - c64_sound generate launches an untracked, uncancellable background playback loop that keeps writing device state after the call returns
+
+- **Area:** Background tasks, meta workflows, artifacts, and cancellation
+- **Severity:** P2
+- **Dimensions:** sid-audio, background-task, timeout-cancellation, backend-switching
+- **Confidence:** High
+- **Effort:** M
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/audio.ts `music_generate` (851-930, `void (async () => {...})()` at 890); src/c64Client.ts `sidNoteOn`/`sidSetVolume` (via facadePromise); src/device.ts ViceBackend.withClient monitorQueue
+
+**Failure scenario:**
+`c64_sound {op:"generate", steps:64, tempoMs:500}` returns immediately ("Scheduled …") but spawns a **detached** async loop that writes SID registers once per step for up to `steps*tempoMs` (32 s here). Nothing tracks or can stop this loop: `c64_system stop_all_tasks` does not know about it, server shutdown does not await it, and a `c64_select_backend` mid-playback makes the remaining `sidNoteOn` writes resolve against `this.facadePromise` — i.e. they play onto whatever backend is now active (potentially real hardware the user just switched to). On VICE, each note acquires the `monitorQueue`, so a long arpeggio serializes behind/ahead of every other VICE operation for its whole duration. The tool's `success:true` claims completion while playback is still ongoing and unmanaged.
+
+**Current-code evidence:** src/tools/audio.ts:890-914 — fire-and-forget IIFE with only a `catch` that logs; no handle, cancellation token, or task registration.
+
+**Why production-reachable:** `generate` is a documented quick-playback op; long step counts are permitted by the schema.
+
+**Why this degrades C64 control, development, or trust:** Unmanaged live device work that outlives the request, can retarget across a backend switch (physical-state hazard), monopolizes the VICE monitor, and cannot be stopped except by `sid_reset`.
+
+**Backend and recovery angle:** All backends. Recovery: `c64_sound reset`/`silence_all`, if the loop hasn't retargeted.
+
+**Relation to existing HARD01 findings:** Shares the switch-retarget mechanism with HARD01-016 but is a distinct lifecycle/cancellation defect (untracked detached work).
+
+**Minimal fix sketch:** Pin the facade at call time and pass it through the loop; register the loop as a cancellable task (integrate with the background-task registry) and stop it on shutdown/backend switch.
+
+**Regression test strategy:** Unit test asserting a switch during playback does not route later notes to the new facade; test that shutdown awaits/cancels the loop.
+
+**Fix risk:** Changing to a tracked task alters the fire-and-forget contract; keep the immediate return but add a stop handle.
+
+### HARD01-031 - Reading the c64://platform/status resource performs a blocking device REST probe, so a slow/unreachable Ultimate stalls the resource channel
+
+- **Area:** MCP protocol, stdio, tool dispatch, prompts, and resources
+- **Severity:** P3
+- **Dimensions:** mcp-protocol, c64u-rest, capability, timeout-cancellation
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/mcp-server.ts ReadResource handler (197-251) → `renderPlatformStatusMarkdown` (523-578) → `client.getNativeEndpointCapabilities` (src/c64Client.ts:259-276) → `C64uBackend.getInputState` (src/device.ts:349-353, 10 s http timeout at 251)
+
+**Failure scenario:**
+An MCP client reads the `c64://platform/status` resource (the documented pre-flight for native input). On the c64u backend, `renderPlatformStatusMarkdown` `await`s `getNativeEndpointCapabilities()`, which issues a live `GET machine:input` against the device using the facade's 10 s Axios timeout. If the Ultimate is booting, unreachable, or slow, the ReadResource call blocks for up to 10 s (and, per HARD01-004, poisons the cached result to "unknown" permanently). Resource reads are expected to be cheap, side-effect-free metadata fetches; clients that prefetch resources can stall, and the probe is a real device interaction hidden behind a "status" read.
+
+**Current-code evidence:** As cited; the ReadResource handler has no timeout of its own and awaits the device probe inline.
+
+**Why production-reachable:** Agents are explicitly told to read this resource before native input (AGENTS.md); device boot/network latency is routine.
+
+**Why this degrades C64 control, development, or trust:** A metadata resource performing a blocking, side-effecting, permanently-cached device call couples MCP resource latency to hardware reachability and violates the "read status before acting" guidance it is meant to support.
+
+**Backend and recovery angle:** c64u only (u2/vice return static capability values). Compounds HARD01-004's permanent caching.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-004 (that is the cache poisoning; this is the resource-read blocking/side-effect surface).
+
+**Minimal fix sketch:** Give the probe a short timeout (e.g. 1-2 s) independent of the 10 s facade timeout, and/or make the status resource report "unknown/not-yet-probed" without blocking, probing lazily in the background.
+
+**Regression test strategy:** Test with a facade whose getInputState never resolves; assert ReadResource returns within the short timeout with a non-blocking status.
+
+**Fix risk:** Shorter probe timeout could report "unknown" on a merely-slow device; pair with the non-caching fix from HARD01-004.
+
+### HARD01-032 - SID frequency register formula uses 2^16 instead of the SID's 2^24 divisor, so every generated note is ~256x too low in pitch
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P2
+- **Dimensions:** sid-audio, memory-io, tool-contract, documentation-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/c64Client.ts `hzToSidFrequency` (2190-2195), `sidNoteOn` (856-906); src/sidwaveCompiler.ts `hzToSidFrequency` (190-193); src/knowledge.ts SID formula doc (line 100); c64://sound/sid/spec
+
+**Failure scenario:**
+`c64_sound {op:"note_on", note:"A4"}` (or `frequencyHz:440`, or `music_generate`, or any sidwave compilation). `hzToSidFrequency` computes `round(hz * 65536 / phi2)`. The SID oscillator is a **24-bit** phase accumulator: the correct register value is `Fn = Fout * 2^24 / Fclk` (Fclk≈985248 PAL), i.e. the divisor constant must be 16777216 (2^24), not 65536 (2^16). For A4=440 Hz the code yields `round(440*65536/985248) = 29` (`$001D`), which plays back as `29*985248/2^24 ≈ 1.7 Hz` — sub-audible — instead of the correct `Fn≈7493` (`$1D45`). Every note is a factor of 256 too low. The tool reports success and the register write happens; only the pitch is wrong.
+
+**Current-code evidence:** src/c64Client.ts:2192 `Math.round((hz * 65536) / phi2)`; identical error in src/sidwaveCompiler.ts:192; and src/knowledge.ts:100 documents the same wrong formula (`freq_value = (frequency_Hz × 65536) / clock_rate`), so the mistake is codebase-wide and self-consistent. The audio test (test/audioModule.test.mjs:455) only asserts the call succeeds, never the register value, so it does not catch it.
+
+**Why production-reachable:** `sid_note_on`, `music_generate`, and sidwave compilation are the documented SID-playback paths.
+
+**Why this degrades C64 control, development, or trust:** The SID melodic feature is fundamentally broken — notes are inaudible/wrong-octave — while reporting success; a user composing music gets no usable pitch.
+
+**Backend and recovery angle:** All backends that write SID registers (C64U/U2 firmware and VICE memory).
+
+**Relation to existing HARD01 findings:** Independent of HARD01-034 (envelope gating) though both affect SID playback.
+
+**Minimal fix sketch:** Replace the `65536` constant with `16777216` (2^24) in both `hzToSidFrequency` implementations and correct the knowledge.ts formula; clamp to 16-bit as today.
+
+**Regression test strategy:** Unit test asserting `hzToSidFrequency(440,"PAL") ≈ 7493` and that `sid_note_on note:"A4"` writes `$45 $1D` to `$D400/$D401`.
+
+**Hardware validation:** Play A4 on real hardware / VICE and confirm audible ~440 Hz.
+
+**Fix risk:** None arithmetically; verify NTSC constant (1022727) with the same 2^24 divisor.
+
+### HARD01-033 - music_generate never releases the gate between notes, so the ADSR envelope only attacks once and later notes do not articulate
+
+- **Area:** Program execution, BASIC, assembler, memory, graphics, and SID
+- **Severity:** P3
+- **Dimensions:** sid-audio, tool-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/audio.ts `music_generate` playback loop (890-914); src/c64Client.ts `sidNoteOn` (856-906), `sidNoteOff` (908-920)
+
+**Failure scenario:**
+`c64_sound {op:"generate", steps:8}` plays an arpeggio by calling `sidNoteOn` once per step with GATE set (control bit 0 = 1) and **never calling `sidNoteOff` between notes**. The SID envelope generator only (re)starts its attack/decay when it sees a rising edge on GATE; because GATE stays continuously high across all steps, only the first note articulates (attack→decay→sustain) and every subsequent note merely changes frequency while the envelope sits in sustain. With `sustain:15, release:0`, successive notes blur together with no re-attack — not the intended arpeggio articulation.
+
+**Current-code evidence:** src/tools/audio.ts:893-909 — loop of `sidNoteOn` with a single trailing `sidNoteOff(1)`; no gate-off between steps.
+
+**Why production-reachable:** `generate` is the documented quick-playback op.
+
+**Why this degrades C64 control, development, or trust:** Musical output does not match the promised note sequence; combined with HARD01-032 the feature is doubly broken.
+
+**Backend and recovery angle:** All backends.
+
+**Relation to existing HARD01 findings:** Distinct from HARD01-032 (pitch) and HARD01-030 (lifecycle).
+
+**Minimal fix sketch:** Between notes, clear GATE (write control with bit0=0) briefly before the next `sidNoteOn`, or expose a per-note gate-retrigger.
+
+**Regression test strategy:** Unit test asserting the register write sequence includes a gate-low write between successive notes.
+
+**Fix risk:** Minor timing change to playback.
+
+### HARD01-034 - Printer tools are gated to c64u only, so they are unavailable on U2 despite the platform advertising printer-integration
+
+- **Area:** Backend selection and platform/capability contract
+- **Severity:** P3
+- **Dimensions:** capability, u2-variant, documentation-contract
+- **Confidence:** High
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/tools/printer.ts `printerModule` (295-...) and src/tools/registry/printer.ts `printerModuleGroup` (170-...) — both omit `supportedPlatforms`; src/tools/types.ts `defineToolModule` default (338-340) → `["c64u"]`; src/platform.ts `PLATFORM_FEATURES.u2` (23-26) lists `printer-integration`
+
+**Failure scenario:**
+Active backend u2. Invoking `c64_printer` (any op) fails with `ToolUnsupportedPlatformError` because both printer modules default their `supportedPlatforms` to `["c64u"]` (neither sets it). Yet the `c64://platform/status` resource lists `printer-integration` as an active feature for u2 (PLATFORM_FEATURES.u2), and printing is just a BASIC program run to device 4 that U2 firmware supports. The capability advertisement and the runtime gate contradict each other, and a real, supported u2 printing workflow is blocked.
+
+**Current-code evidence:** As cited — printer modules never call `supportedPlatforms`, so the `["c64u"]` module default applies; platform.ts advertises printer-integration for u2.
+
+**Why production-reachable:** U2-family users following the platform-status capability list.
+
+**Why this degrades C64 control, development, or trust:** Advertised capability is unusable on u2; the status resource misleads.
+
+**Backend and recovery angle:** U2 blocked; c64u works; VICE has no printer (correctly excluded).
+
+**Relation to existing HARD01 findings:** Distinct capability/gating mismatch from HARD01-004/016.
+
+**Minimal fix sketch:** Set `supportedPlatforms: ["c64u","u2"]` on the printer modules (or align PLATFORM_FEATURES if u2 truly lacks printing).
+
+**Regression test strategy:** Platform-capability test asserting c64_printer is in u2's supported-tools list iff printer-integration is advertised for u2.
+
+**Fix risk:** None if U2 firmware runs the printer BASIC (it runs arbitrary BASIC); confirm device-4 availability on U2.
+
+### HARD01-035 - VICE configSet/configBatchUpdate coerce any digit-only string to an integer, misapplying or rejecting string resources
+
+- **Area:** VICE Binary Monitor and process lifecycle
+- **Severity:** P3
+- **Dimensions:** config, vice-monitor, tool-contract
+- **Confidence:** Medium
+- **Effort:** S
+- **Status:** OPEN
+- **Files/functions reviewed:** src/device.ts `ViceBackend.configSet` (908-915), `configBatchUpdate` (917-935); src/vice/viceClient.ts `resourceSet` (417-443) and BM spec §0x52 (type mismatch → 0x81)
+
+**Failure scenario:**
+`c64_config set` on VICE for a **string** resource whose value happens to be all digits (e.g. a directory/image path or label like `"1541"` used as text). `configSet` does `const numValue = Number(value); parsed = !isNaN(numValue) && value.trim()!=="" ? numValue : value`, so `"1541"` becomes the integer `1541` and is sent to `resourceSet` as an int payload. Per the BM spec, if the underlying VICE resource is a string, the monitor returns `0x81` (type mismatch) — or, for a resource that accepts ints, the wrong type is silently applied. The user's explicit string value is lost with no signal at the tool layer.
+
+**Current-code evidence:** src/device.ts:909-910 and 924-925 apply the same `isNaN(Number(...))` heuristic to every value; `configBatchUpdate` records the per-item error but `configSet` surfaces only a generic failure.
+
+**Why production-reachable:** Any VICE `c64_config` set/batch where the intended string value is numeric text.
+
+**Why this degrades C64 control, development, or trust:** Config values are silently type-coerced; string resources cannot be set to numeric-looking strings, and failures may be misclassified.
+
+**Backend and recovery angle:** VICE only (c64u sends values as strings to firmware).
+
+**Relation to existing HARD01 findings:** Independent.
+
+**Minimal fix sketch:** Look up the resource's declared type (VICE `resourceGet` reports int vs string) before coercing, or expose an explicit value-type argument; do not infer type from the value's shape.
+
+**Regression test strategy:** BM stub asserting a string resource set to `"1541"` sends a string payload, not an int.
+
+**Fix risk:** Requires a resource-type probe or schema; keep the numeric fast-path for known int resources.
+
+## Suggested fix batches
+
+### Batch A - Ultimate REST truthfulness
+- HARD01-011 (ignore `errors` array), HARD01-010 (path double-encoding), HARD01-017 (paused-on-resume-failure), HARD01-002/003 (power_cycle verification + cleanup)
+- Rationale: all concern C64uBackend/powerCycle reporting success without confirming device state; one mock-Ultimate harness returning 200+errors, nested paths, and menu matrices protects the group.
+
+### Batch B - VICE lifecycle and transport
+- HARD01-012 (BM response timeout), HARD01-013 (orphaned processes), HARD01-014 (joystick Joyport), HARD01-026 (reset readiness), HARD01-015 (checkpoint mask)
+- Rationale: shared ViceClient/ViceBackend/process.ts surface; one BM stub + managed-process test harness covers timeout, signal cleanup, joyport, readiness.
+
+### Batch C - Backend-switch and config consistency
+- HARD01-004, HARD01-005, HARD01-006, HARD01-016, HARD01-025, HARD01-027
+- Rationale: single config source of truth + facade pinning + module-relative asset resolution; one multi-backend mock-facade harness plus a config-fixture suite.
+
+### Batch D - Program-execution truthfulness
+- HARD01-018, HARD01-019, HARD01-020, HARD01-021, HARD01-007, HARD01-008
+- Rationale: assembler entry mechanism + poll validator rewrite + BASIC generators; VICE fixture asserting real program effects.
+
+### Batch E - SID audio correctness
+- HARD01-032 (frequency formula), HARD01-033 (gate re-trigger), HARD01-030 (untracked playback)
+- Rationale: all in the SID playback path (hzToSidFrequency, music_generate); one register-write assertion fixture plus a real-frequency HIL/VICE check covers pitch and articulation.
+
+### Batch F - Background/meta lifecycle, artifacts, secrets, capability
+- HARD01-022, HARD01-028, HARD01-029, HARD01-024, HARD01-023, HARD01-031, HARD01-034, HARD01-035
+- Rationale: task persistence/accounting, path containment, log redaction, drive-shape normalisation, resource-probe timeout, printer u2 gating, VICE config coercion.
+
+## Recommended validation gate
+
+- **Mock-Ultimate error-array test**: 200 responses carrying non-empty `errors` for run/mount/config must yield tool `isError` (HARD01-011); nested-path request line preserves `/` separators (HARD01-010).
+- **Concurrent backend-switch harness** with mock c64u/u2/vice facades: a slow write-verify started on one backend must complete against the facade it began with despite an interleaved `c64_select_backend` (HARD01-016); capability probe caching retries after a transient failure (HARD01-004).
+- **VICE BM stub**: unanswered command rejects within the request timeout and the monitor queue releases (HARD01-012); reset returns success:false when readiness fails (HARD01-026); an 0xA2 Joyport command is emitted for joystick ops (HARD01-014).
+- **Managed/unmanaged VICE lifecycle**: SIGTERM to the server leaves no orphaned VICE/Xvfb (HARD01-013).
+- **Config-fixture suite**: layered files resolve identical host/port/password through both loaders (HARD01-005); a project-cwd `.c64bridge.json` is honoured (HARD01-006); malformed JSON falls back with a warning (HARD01-027).
+- **Program fixtures**: VICE run of the `upload_run_asm` example writes `$01` to `$0400` (HARD01-018); poll validator reports "crashed" when only free-running registers change (HARD01-019) and never reads `$DC0D/$DD0D` on hardware (HARD01-020); generated printer program contains no `""` inside string literals (HARD01-007).
+- **Filesystem/secrets**: `runId:"../escape"` is rejected (HARD01-029); RAG loads bundled indexes from a foreign cwd (HARD01-025); debug logs mask `X-Password` (HARD01-024).
+- **Background tasks**: reloaded "running" tasks are re-armed or downgraded (HARD01-022); `{success:false}` iterations are recorded as failures (HARD01-028).
+- Controlled HIL validation (C64U/U64/U2, managed VICE) only after fixes land; never during this review.
+
+## Leads not yet proven
+
+- **Lead:** `mergePlatforms` unions module and tool `supportedPlatforms`, so a tool can never *narrow* below its module default.
+  - **Area:** Backend selection and platform/capability contract
+  - **Why it matters:** A future tool that sets a narrower `supportedPlatforms` than its module would be exposed/allowed on unsupported platforms.
+  - **Evidence so far:** src/tools/types.ts:488-504 unions the sets; no current tool narrows (all either match or widen), so it is latent, not live.
+  - **Next check:** Confirm no grouped tool relies on narrowing, then treat as a hardening change.
+
+- **Lead:** Tool results attach a top-level `metadata` field (src/tools/responses.ts, src/mcp-server.ts `toCallToolResult`) rather than the MCP `_meta`.
+  - **Area:** MCP protocol
+  - **Why it matters:** Spec-compliant clients ignore `metadata`; rich per-tool metadata may be silently dropped (though `structuredContent` duplicates most of it).
+  - **Evidence so far:** `toCallToolResult` copies `metadata` verbatim; MCP CallToolResult defines `_meta`.
+  - **Next check:** Confirm the installed MCP SDK result schema is passthrough (harmless) vs strict (rejects), and whether any client consumes `metadata`.
+
+- **Lead:** `injectKeyboardQueue` writes the 10-byte KERNAL buffer at `$0277` then NDX at `$00C6` as two separate DMA writes; a mid-write KERNAL IRQ could observe a partially updated buffer.
+  - **Area:** input
+  - **Why it matters:** Rare keystroke corruption independent of HARD01-009's drain issue.
+  - **Evidence so far:** src/c64Client.ts:1926-1927 orders bytes-before-count (mitigates most cases) but does not pause the machine.
+  - **Next check:** Determine whether Ultimate `:writemem` is atomic relative to the C64 IRQ; if not, quantify the window.
+
+- **Lead:** Video-frame grouping keys on the 16-bit `frameNumber`, which wraps at 65536; a very long reuse-session capture could merge packets from two distinct frames that share a number.
+  - **Area:** streaming / graphics
+  - **Why it matters:** Corrupt reconstructed frame after prolonged capture.
+  - **Evidence so far:** src/streamCapture.ts `groupVideoPackets` groups by raw frameNumber; capture windows are currently short (count ≤ 32), so it is latent.
+  - **Next check:** Confirm firmware frame-number wrap behaviour and whether reuse sessions can accumulate >65536 frames.
+
+## Important limitations
+
+- Review is static/source-only per scope: no state-changing MCP calls, no hardware, and no VICE process were exercised. Medium-confidence findings (HARD01-010, HARD01-011, HARD01-020) rest on the documented firmware/CIA/OpenAPI contracts plus one explicitly stated inference each; a mock-Ultimate or HIL check would raise them to High.
+- The generated OpenAPI client (`generated/c64/index.ts`) and the embeddings JSON were read selectively, not exhaustively; the packaging sweep confirmed `files`/entry wiring but did not build or install the package.
+- Test files were consulted only to confirm why a defect is not already covered, not audited for their own bugs.
+- 31 findings exceed the ≥30 objective; the count is not capped by source quality — additional lower-severity robustness items remain (see Leads) but were left as leads rather than padded into main findings.
+
+## Commands run
+
+- git status --short; git rev-parse --abbrev-ref HEAD; git rev-parse HEAD; date -Iseconds
+- find src -maxdepth 2 -type d; wc -l src/*.ts; find src -type f -name '*.ts' | xargs wc -l | sort -rn
+- Read: src/mcp-server.ts, src/config.ts, src/bootstrap/stdio-logger.ts, src/device.ts, src/c64Client.ts, src/platform.ts
+- Read: src/vice/viceClient.ts, src/vice/process.ts, src/vice/readiness.ts, doc/vice/vice-binary-monitor-spec.md
+- Read: src/tools/types.ts, src/tools/input.ts, src/tools/machineControl.ts, src/tools/memory.ts, src/tools/pollValidator.ts, src/tools/responses.ts
+- Read: src/tools/registry/{index,system,platform,utils,input,stream,disk,sound,program}.ts, src/tools/storage.ts, src/tools/audio.ts
+- Read: src/tools/meta/{background,filesystem,artifacts}.ts, src/tools/translation/basicTokenizer.ts, src/tools/programRunners.ts
+- Read: src/rag/{init,externalFetcher,urlUtils}.ts (selective), src/loggingHttpClient.ts, src/logger.ts (grep)
+- rg/sed/nl over doc/c64u/c64-openapi.yaml, doc/u2/u2-openapi.yaml, generated/c64/index.ts, package.json, doc/developer.md
+- rg surveys: supportedPlatforms, operationPlatforms, drivesList consumers, X-Password handling, path/traversal sinks
+
+- git status --short; git rev-parse --abbrev-ref HEAD; git rev-parse HEAD; date -Iseconds
+- find src -maxdepth 2 -type d; wc -l src/*.ts

--- a/mcp/schemas/c64_input.schema.json
+++ b/mcp/schemas/c64_input.schema.json
@@ -57,7 +57,7 @@
     },
     "port": {
       "type": "integer",
-      "description": "Joystick port (1 = $DC01, 2 = $DC00).",
+      "description": "Joystick port (1 or 2).",
       "minimum": 1,
       "maximum": 2
     },
@@ -178,7 +178,7 @@
   "required": [
     "op"
   ],
-  "description": "Input operations: write_text, key, keyboard, joystick, release_all, state.\n\nOperations:\n- write_text: Send a text string to the keyboard buffer, with PETSCII token expansion. Required inputs: text. Optional inputs: delayMs.\n- key: Tap a single key or hold it for a duration. Required inputs: key. Optional inputs: durationMs, count.\n- joystick: Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers. Required inputs: port, controls, action. Optional inputs: durationMs.\n- keyboard: Send physical C64 keyboard matrix events through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: inputs, transition.\n- release_all: Release every key and joystick control injected through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.\n- state: Read the keys and joystick controls held through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.",
+  "description": "Input operations: write_text, key, keyboard, joystick, release_all, state.\n\nOperations:\n- write_text: Send a text string to the keyboard buffer, with PETSCII token expansion. Required inputs: text. Optional inputs: delayMs.\n- key: Tap a single key or hold it for a duration. Required inputs: key. Optional inputs: durationMs, count.\n- joystick: Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set. Required inputs: port, controls, action. Optional inputs: durationMs.\n- keyboard: Send physical C64 keyboard matrix events through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: inputs, transition.\n- release_all: Release every key and joystick control injected through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.\n- state: Read the keys and joystick controls held through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.",
   "additionalProperties": false,
   "x-c64bridge-operations": [
     {
@@ -274,7 +274,7 @@
     },
     {
       "op": "joystick",
-      "description": "Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers.",
+      "description": "Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set.",
       "required": [
         "port",
         "controls",
@@ -285,14 +285,14 @@
       ],
       "inputSchema": {
         "type": "object",
-        "description": "Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers.",
+        "description": "Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set.",
         "properties": {
           "op": {
             "const": "joystick"
           },
           "port": {
             "type": "integer",
-            "description": "Joystick port (1 = $DC01, 2 = $DC00).",
+            "description": "Joystick port (1 or 2).",
             "minimum": 1,
             "maximum": 2
           },

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "name": "c64bridge",
-  "version": "0.9.3",
+  "version": "1.0.0",
   "description": "Stdio-based Model Context Protocol (MCP) server that bridges Commodore 64 Ultimate hardware with AI agents.",
   "transports": [
     "stdio"

--- a/mcp/tools.json
+++ b/mcp/tools.json
@@ -5668,7 +5668,8 @@
           "When defining characters, remind the user to send the BASIC program returned in the payload."
         ],
         "platforms": [
-          "c64u"
+          "c64u",
+          "u2"
         ]
       }
     },
@@ -8255,7 +8256,7 @@
           },
           "port": {
             "type": "integer",
-            "description": "Joystick port (1 = $DC01, 2 = $DC00).",
+            "description": "Joystick port (1 or 2).",
             "minimum": 1,
             "maximum": 2
           },
@@ -8376,7 +8377,7 @@
         "required": [
           "op"
         ],
-        "description": "Input operations: write_text, key, keyboard, joystick, release_all, state.\n\nOperations:\n- write_text: Send a text string to the keyboard buffer, with PETSCII token expansion. Required inputs: text. Optional inputs: delayMs.\n- key: Tap a single key or hold it for a duration. Required inputs: key. Optional inputs: durationMs, count.\n- joystick: Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers. Required inputs: port, controls, action. Optional inputs: durationMs.\n- keyboard: Send physical C64 keyboard matrix events through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: inputs, transition.\n- release_all: Release every key and joystick control injected through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.\n- state: Read the keys and joystick controls held through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.",
+        "description": "Input operations: write_text, key, keyboard, joystick, release_all, state.\n\nOperations:\n- write_text: Send a text string to the keyboard buffer, with PETSCII token expansion. Required inputs: text. Optional inputs: delayMs.\n- key: Tap a single key or hold it for a duration. Required inputs: key. Optional inputs: durationMs, count.\n- joystick: Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set. Required inputs: port, controls, action. Optional inputs: durationMs.\n- keyboard: Send physical C64 keyboard matrix events through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: inputs, transition.\n- release_all: Release every key and joystick control injected through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.\n- state: Read the keys and joystick controls held through machine:input (a C64U firmware version that provides it, or U64 3.15+). Required inputs: none.",
         "additionalProperties": false,
         "x-c64bridge-operations": [
           {
@@ -8472,7 +8473,7 @@
           },
           {
             "op": "joystick",
-            "description": "Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers.",
+            "description": "Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set.",
             "required": [
               "port",
               "controls",
@@ -8483,14 +8484,14 @@
             ],
             "inputSchema": {
               "type": "object",
-              "description": "Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers.",
+              "description": "Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set.",
               "properties": {
                 "op": {
                   "const": "joystick"
                 },
                 "port": {
                   "type": "integer",
-                  "description": "Joystick port (1 = $DC01, 2 = $DC00).",
+                  "description": "Joystick port (1 or 2).",
                   "minimum": 1,
                   "maximum": 2
                 },

--- a/scripts/mockC64Server.mjs
+++ b/scripts/mockC64Server.mjs
@@ -83,7 +83,12 @@ function sendJson(res, payload = {}, statusCode = 200) {
 function createInitialState() {
   return {
     networkPassword: null,
+    forcedErrors: null,
+    forcedErrorsUrlMatch: null,
+    hangOnMachineInputProbe: false,
     lastPrg: null,
+    lastLoadedPrg: null,
+    loadCount: 0,
     runCount: 0,
     resets: 0,
     reboots: 0,
@@ -154,6 +159,21 @@ const SCREEN_CODE_LOOKUP = (() => {
 
 function toScreenCode(char) {
   return SCREEN_CODE_LOOKUP.get(char) ?? SCREEN_CODE_LOOKUP.get(" ") ?? 0x20;
+}
+
+const KERNAL_KEYBOARD_NDX_ADDRESS = 0x00c6;
+
+/**
+ * Nothing in this mock runs 6502 code to drain the KERNAL keyboard buffer
+ * itself, so a client polling NDX ($00C6) waiting for it to return to zero
+ * would otherwise hang forever. Simulate the KERNAL's IRQ-driven drain with
+ * a short delay so injectKeyboardQueue's poll loop behaves realistically.
+ */
+function simulateKeyboardDrain(state, address) {
+  if (address !== KERNAL_KEYBOARD_NDX_ADDRESS) return;
+  setTimeout(() => {
+    state.memory[KERNAL_KEYBOARD_NDX_ADDRESS] = 0;
+  }, 5);
 }
 
 function seedReadyPrompt(state) {
@@ -275,6 +295,20 @@ export async function startMockC64Server(options = {}) {
       return;
     }
 
+    // Test hook: simulate real firmware soft-failures, which answer HTTP 200
+    // with a non-empty `errors` array rather than a non-2xx status. Consumed
+    // once so a single forced failure does not leak into later requests.
+    if (state.forcedErrors && (!state.forcedErrorsUrlMatch || url.includes(state.forcedErrorsUrlMatch))) {
+      const errors = state.forcedErrors;
+      state.forcedErrors = null;
+      state.forcedErrorsUrlMatch = null;
+      // Drain any request body so an unread upload cannot corrupt a reused
+      // keep-alive connection's framing.
+      for await (const _chunk of req) { /* discard */ }
+      sendJson(res, { result: "error", errors });
+      return;
+    }
+
     if (method === "GET" && (url === "/" || url.startsWith("/?"))) {
       sendJson(res, { status: "ok", host: "mock" });
       return;
@@ -297,7 +331,10 @@ export async function startMockC64Server(options = {}) {
           enabled: driveState.power !== "off",
           power: driveState.power,
           mode: driveState.mode,
-          image: driveState.mountedImage,
+          // Mirror the real firmware's DriveInfo shape (image_path is a
+          // plain string), not the internal mount-params object.
+          image_path: driveState.mountedImage?.image ?? null,
+          type: driveState.mountedImage?.type ?? driveState.mode ?? null,
         };
       }
       sendJson(res, { drives });
@@ -340,6 +377,11 @@ export async function startMockC64Server(options = {}) {
     }
 
     if (method === "GET" && url === "/v1/machine:input") {
+      if (state.hangOnMachineInputProbe) {
+        // Test hook: never respond, to prove a caller cannot be blocked on
+        // this probe (HARD01-031). Deliberately does not call res.end().
+        return;
+      }
       sendJson(res, state.inputState);
       return;
     }
@@ -393,6 +435,27 @@ export async function startMockC64Server(options = {}) {
       const prg = Buffer.concat(chunks);
       state.lastPrg = prg;
       state.runCount += 1;
+
+      sendJson(res, { result: "ok", bytes: prg.length });
+      return;
+    }
+
+    if (method === "POST" && url === "/v1/runners:load_prg") {
+      const chunks = [];
+      for await (const chunk of req) {
+        chunks.push(chunk);
+      }
+
+      const prg = Buffer.concat(chunks);
+      state.lastLoadedPrg = prg;
+      state.loadCount += 1;
+
+      // Mirror real firmware: place the PRG body at its embedded load
+      // address without starting it (no RUN, no BASIC pointer changes).
+      if (prg.length >= 2) {
+        const loadAddress = prg.readUInt16LE(0);
+        state.memory.set(prg.subarray(2), loadAddress);
+      }
 
       sendJson(res, { result: "ok", bytes: prg.length });
       return;
@@ -506,6 +569,7 @@ export async function startMockC64Server(options = {}) {
       state.memory.set(bytes, address);
       state.lastWrite = { address, bytes };
       state.writeLog.push({ address, bytes: Buffer.from(bytes) });
+      simulateKeyboardDrain(state, address);
 
       sendJson(res, { result: "wrote", address, length: bytes.length });
       return;
@@ -525,6 +589,7 @@ export async function startMockC64Server(options = {}) {
       state.memory.set(bytes, address);
       state.lastWrite = { address, bytes };
       state.writeLog.push({ address, bytes: Buffer.from(bytes) });
+      simulateKeyboardDrain(state, address);
 
       sendJson(res, { result: "wrote", address, length: bytes.length });
       return;

--- a/scripts/mockC64Server.mjs
+++ b/scripts/mockC64Server.mjs
@@ -94,6 +94,7 @@ function createInitialState() {
     reboots: 0,
   poweroffs: 0,
     memory: new Uint8Array(0x10000),
+    heartbeat: null,
     lastWrite: null,
     writeLog: [],
     lastRequest: null,
@@ -162,18 +163,79 @@ function toScreenCode(char) {
 }
 
 const KERNAL_KEYBOARD_NDX_ADDRESS = 0x00c6;
+const KERNAL_KEYBOARD_BUFFER_ADDRESS = 0x0277;
+
+const SYS_COMMAND_PATTERN = /SYS\s*\d+/i;
+const HEARTBEAT_ADDRESS = 0x0400; // Screen-RAM byte the ASM liveness poller watches.
+const HEARTBEAT_GRANULARITY_MS = 10; // Well below the poll interval so consecutive liveness reads always differ.
+const HEARTBEAT_DURATION_MS = 1000; // How long a SYS-triggered program keeps "running".
 
 /**
  * Nothing in this mock runs 6502 code to drain the KERNAL keyboard buffer
  * itself, so a client polling NDX ($00C6) waiting for it to return to zero
  * would otherwise hang forever. Simulate the KERNAL's IRQ-driven drain with
  * a short delay so injectKeyboardQueue's poll loop behaves realistically.
+ *
+ * When the queued text looks like a typed `SYSnnnnn` command (the trigger
+ * upload_run_asm uses to enter an assembled program), also record a
+ * time-computed "alive" window (consumed by readMemoryWithHeartbeat). This
+ * mock never executes 6502 code, so a liveness poller watching screen RAM
+ * would otherwise see no progression. Recording a descriptor rather than
+ * mutating memory from a background timer is deliberate: nothing advances
+ * asynchronously, so an unrelated later test that merely shares this server
+ * instance can never observe a stray screen-RAM mutation.
  */
 function simulateKeyboardDrain(state, address) {
   if (address !== KERNAL_KEYBOARD_NDX_ADDRESS) return;
+  const pending = state.memory[KERNAL_KEYBOARD_NDX_ADDRESS] ?? 0;
+  const queued = pending > 0
+    ? Uint8Array.from(state.memory.subarray(KERNAL_KEYBOARD_BUFFER_ADDRESS, KERNAL_KEYBOARD_BUFFER_ADDRESS + pending))
+    : null;
   setTimeout(() => {
     state.memory[KERNAL_KEYBOARD_NDX_ADDRESS] = 0;
+    if (!queued) return;
+    const text = Buffer.from(queued).toString("ascii");
+    if (!SYS_COMMAND_PATTERN.test(text)) return;
+    state.heartbeat = {
+      address: HEARTBEAT_ADDRESS,
+      startedAt: Date.now(),
+      durationMs: HEARTBEAT_DURATION_MS,
+      baseValue: state.memory[HEARTBEAT_ADDRESS] ?? 0,
+    };
   }, 5);
+}
+
+/**
+ * Serve a screen-RAM read, overlaying a synthetic, monotonically advancing
+ * byte at the heartbeat address while a SYS-triggered "alive" window is open.
+ * The overlay is a pure function of elapsed time applied only to the returned
+ * copy, so it never mutates stored memory and never advances on its own.
+ */
+function readMemoryWithHeartbeat(state, address, length) {
+  const bytes = state.memory.slice(address, address + length);
+  const heartbeat = state.heartbeat;
+  if (!heartbeat) return bytes;
+  const elapsed = Date.now() - heartbeat.startedAt;
+  if (elapsed < 0 || elapsed >= heartbeat.durationMs) return bytes;
+  const offset = heartbeat.address - address;
+  if (offset < 0 || offset >= bytes.length) return bytes;
+  const ticks = Math.floor(elapsed / HEARTBEAT_GRANULARITY_MS);
+  bytes[offset] = (heartbeat.baseValue + ticks) & 0xff;
+  return bytes;
+}
+
+/**
+ * Any explicit write covering the heartbeat address means a client has taken
+ * over screen RAM, so end the simulated "alive" window and let the real stored
+ * bytes show through again. This keeps a lingering heartbeat from corrupting a
+ * later writeMemory/readMemory round-trip in a shared-server test.
+ */
+function cancelHeartbeatOnWrite(state, address, length) {
+  const heartbeat = state.heartbeat;
+  if (!heartbeat) return;
+  if (address <= heartbeat.address && heartbeat.address < address + length) {
+    state.heartbeat = null;
+  }
 }
 
 function seedReadyPrompt(state) {
@@ -534,7 +596,7 @@ export async function startMockC64Server(options = {}) {
       const lengthValue = routeUrl.searchParams.get("length") ?? "256";
       const address = parseNumeric(addressValue);
       const length = Math.max(0, parseNumeric(lengthValue, 10));
-      const bytes = state.memory.slice(address, address + length);
+      const bytes = readMemoryWithHeartbeat(state, address, length);
 
       const accept = String(req.headers["accept"] || "");
       if (accept.includes("application/octet-stream")) {
@@ -569,6 +631,7 @@ export async function startMockC64Server(options = {}) {
       state.memory.set(bytes, address);
       state.lastWrite = { address, bytes };
       state.writeLog.push({ address, bytes: Buffer.from(bytes) });
+      cancelHeartbeatOnWrite(state, address, bytes.length);
       simulateKeyboardDrain(state, address);
 
       sendJson(res, { result: "wrote", address, length: bytes.length });
@@ -589,6 +652,7 @@ export async function startMockC64Server(options = {}) {
       state.memory.set(bytes, address);
       state.lastWrite = { address, bytes };
       state.writeLog.push({ address, bytes: Buffer.from(bytes) });
+      cancelHeartbeatOnWrite(state, address, bytes.length);
       simulateKeyboardDrain(state, address);
 
       sendJson(res, { result: "wrote", address, length: bytes.length });

--- a/src/c64Client.ts
+++ b/src/c64Client.ts
@@ -65,6 +65,22 @@ export interface C64ClientOptions {
   forceC64uFacade?: boolean;
 }
 
+/** Raised when the KERNAL keyboard buffer did not drain before another chunk
+ * could safely be queued. Callers must report this as partial delivery. */
+export class KeyboardQueueDrainTimeoutError extends Error {
+  readonly delivered: number;
+  readonly requested: number;
+  readonly timeoutMs: number;
+
+  constructor(delivered: number, requested: number, timeoutMs: number) {
+    super(`Keyboard queue did not drain after ${timeoutMs}ms; delivered ${delivered} of ${requested} byte(s). Resume the machine and retry the remaining input.`);
+    this.name = "KeyboardQueueDrainTimeoutError";
+    this.delivered = delivered;
+    this.requested = requested;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export type NativeEndpointAvailability = "available" | "unavailable" | "unknown";
 
 export interface NativeEndpointCapabilities {
@@ -94,6 +110,34 @@ function menuMatrixIncludes(matrix: Uint8Array, expected: string): boolean {
   const normalizedExpected = expected.replace(/\s+/g, " ").toUpperCase();
   return [screenCodesToAscii(characters), petsciiToAscii(characters)]
     .some((text) => text.replace(/\s+/g, " ").toUpperCase().includes(normalizedExpected));
+}
+
+function selectedMenuRow(matrix: Uint8Array): number | null {
+  // The firmware contract exposes a 40x25 character matrix followed by its
+  // colour matrix. A selected menu row is rendered with one uniform colour
+  // distinct from the normal rows. Reject malformed/ambiguous matrices.
+  if (matrix.length < 2_000) return null;
+  const colours = matrix.subarray(1_000, 2_000);
+  const rows: number[] = [];
+  for (let row = 0; row < 25; row += 1) {
+    const cells = colours.subarray(row * 40, row * 40 + 40);
+    if (cells.length === 40 && cells.every((value) => value === cells[0])) rows.push(row);
+  }
+  if (rows.length === 0) return null;
+  const normal = new Map<number, number>();
+  for (const row of rows) normal.set(colours[row * 40]!, (normal.get(colours[row * 40]!) ?? 0) + 1);
+  const [colour, count] = [...normal.entries()].sort((a, b) => b[1] - a[1])[0] ?? [];
+  if (colour === undefined || count === undefined) return null;
+  const selected = rows.filter((row) => colours[row * 40] !== colour);
+  return selected.length === 1 ? selected[0]! : null;
+}
+
+function selectedMenuRowIncludes(matrix: Uint8Array, expected: string): boolean {
+  const row = selectedMenuRow(matrix);
+  if (row === null) return false;
+  const text = [screenCodesToAscii(matrix.subarray(row * 40, row * 40 + 40)), petsciiToAscii(matrix.subarray(row * 40, row * 40 + 40))]
+    .map((value) => value.replace(/\s+/g, " ").toUpperCase());
+  return text.some((value) => value.includes(expected.replace(/\s+/g, " ").toUpperCase()));
 }
 
 function isMissingEndpoint(error: unknown): boolean {
@@ -246,6 +290,16 @@ export class C64Client {
     return this.getActiveBackendType();
   }
 
+  /**
+   * Snapshot the facade currently active for this invocation. A multi-step
+   * flow (pause/read/write/resume, or repeated polling) must resolve the
+   * facade once and reuse that same instance for every step, so a concurrent
+   * `switchBackend` cannot retarget an operation already underway.
+   */
+  async pinFacade(): Promise<C64Facade> {
+    return this.facadePromise;
+  }
+
   async getActiveBackendType(): Promise<DeviceType> {
     await this.initPromise;
     return this.activeType;
@@ -271,6 +325,13 @@ export class C64Client {
         .then(() => "available" as const)
         .catch((error) => isMissingEndpoint(error) ? "unavailable" as const : "unknown" as const);
       this.machineInputCapabilityProbes.set(facade.type, probe);
+      // A transport error is not a capability result. Keep confirmed states,
+      // but make a later resource read retry rather than poisoning the cache.
+      void probe.then((result) => {
+        if (result === "unknown" && this.machineInputCapabilityProbes.get(facade.type) === probe) {
+          this.machineInputCapabilityProbes.delete(facade.type);
+        }
+      });
     }
     return { machineInput: await probe, machineMenuScreen: "unknown" };
   }
@@ -621,9 +682,36 @@ export class C64Client {
     }
   }
 
+  /**
+   * Assemble, load, and execute a pure machine-code program. Loading a PRG
+   * with LOAD+RUN (the generic path used by {@link runPrg}) is only correct
+   * for tokenized BASIC text: RUN misinterprets raw 6510 opcodes as BASIC
+   * tokens, and setting BASIC's TXTTAB/VARTAB/ARYTAB/STREND to the code
+   * range corrupts the workspace. Instead this loads the assembled bytes
+   * without running them, then types `SYS <entry>` to transfer control
+   * directly to the first assembled instruction, whatever its address.
+   */
   async uploadAndRunAsm(program: string): Promise<RunBasicResult> {
-    const prg = assemblyToPrg(program);
-    return this.runPrg(prg);
+    try {
+      const prg = assemblyToPrg(program);
+      if (prg.length < 2) {
+        return { success: false, details: { message: "Assembled program produced no output" } };
+      }
+      const entryAddress = prg.readUInt16LE(0);
+      const facade = await this.facadePromise;
+      const loadResult = await facade.loadPrg(prg);
+      if (!loadResult.success) {
+        return { success: false, details: loadResult.details };
+      }
+      const sysCommand = Buffer.from(`SYS${entryAddress}\r`, "ascii");
+      const injectResult = await this.injectKeyboardQueue(sysCommand, { pinnedFacade: facade });
+      return {
+        success: true,
+        details: { load: loadResult.details, entryAddress, delivered: injectResult.delivered },
+      };
+    } catch (error) {
+      return { success: false, details: this.normaliseError(error) };
+    }
   }
 
   async runPrg(prg: Uint8Array | Buffer): Promise<RunBasicResult> {
@@ -740,14 +828,14 @@ export class C64Client {
     }
   }
 
-  async readMemory(addressInput: string, lengthInput: string): Promise<MemoryReadResult> {
+  async readMemory(addressInput: string, lengthInput: string, pinnedFacade?: C64Facade): Promise<MemoryReadResult> {
     try {
       const resolved = resolveAddressSymbol(addressInput);
       const address = resolved ?? this.parseNumeric(addressInput);
       const length = this.parseNumeric(lengthInput);
       validateMemoryRange(address, length);
 
-      const rawBytes = await this.readMemoryRaw(address, length);
+      const rawBytes = await this.readMemoryRaw(address, length, pinnedFacade);
       const bytes = rawBytes.slice(0, length);
 
       return {
@@ -766,7 +854,7 @@ export class C64Client {
     }
   }
 
-  async writeMemory(addressInput: string, bytesInput: string): Promise<RunBasicResult> {
+  async writeMemory(addressInput: string, bytesInput: string, pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     try {
       const resolved = resolveAddressSymbol(addressInput);
       const address = resolved ?? this.parseNumeric(addressInput);
@@ -776,7 +864,7 @@ export class C64Client {
       // Prefer PUT with hex data for up to 128 bytes; fall back to POST binary for larger writes
       const addrStr = this.formatAddress(address);
       try {
-        const facade = await this.facadePromise;
+        const facade = pinnedFacade ?? await this.facadePromise;
         await facade.writeMemory(address, dataBuffer);
         return {
           success: true,
@@ -826,10 +914,10 @@ export class C64Client {
 
   // --- SID/Music helpers ---
 
-  async sidSetVolume(volume: number): Promise<RunBasicResult> {
+  async sidSetVolume(volume: number, pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     const clamped = Math.max(0, Math.min(15, Math.floor(volume)));
     const byte = Buffer.from([clamped]);
-    return this.writeMemory("$D418", this.bytesToHex(byte));
+    return this.writeMemory("$D418", this.bytesToHex(byte), pinnedFacade);
   }
 
   async sidReset(hard = false): Promise<RunBasicResult> {
@@ -864,7 +952,7 @@ export class C64Client {
     decay?: number; // 0..15
     sustain?: number; // 0..15
     release?: number; // 0..15
-  }): Promise<RunBasicResult> {
+  }, pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     const voice = options.voice ?? 1;
     if (voice < 1 || voice > 3) {
       return { success: false, details: { message: "Voice must be 1..3" } };
@@ -897,7 +985,7 @@ export class C64Client {
     const base = 0xd400 + (voice - 1) * 7;
     const bytes = Buffer.from([freqLo, freqHi, pwLo, pwHi, ctrl, ad, sr]);
     try {
-      const facade = await this.facadePromise;
+      const facade = pinnedFacade ?? await this.facadePromise;
       await facade.writeMemory(base, bytes);
       return { success: true };
     } catch (error) {
@@ -905,13 +993,13 @@ export class C64Client {
     }
   }
 
-  async sidNoteOff(voice: 1 | 2 | 3): Promise<RunBasicResult> {
+  async sidNoteOff(voice: 1 | 2 | 3, pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     if (voice < 1 || voice > 3) {
       return { success: false, details: { message: "Voice must be 1..3" } };
     }
     const ctrlAddr = 0xd400 + (voice - 1) * 7 + 4;
     try {
-      const facade = await this.facadePromise;
+      const facade = pinnedFacade ?? await this.facadePromise;
       await facade.writeMemory(ctrlAddr, Buffer.from([0x00]));
       return { success: true };
     } catch (error) {
@@ -935,24 +1023,24 @@ export class C64Client {
     return facade.info();
   }
 
-  async pause(): Promise<RunBasicResult> {
+  async pause(pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     try {
-      if (await this.shouldUseC64uMockBypass()) {
+      if (!pinnedFacade && await this.shouldUseC64uMockBypass()) {
         const res = await this.api.v1.machinePauseUpdate(":pause");
         return { success: true, details: res.data };
       }
-      const facade = await this.facadePromise;
+      const facade = pinnedFacade ?? await this.facadePromise;
       return await facade.pause();
     } catch (error) { return { success: false, details: this.normaliseError(error) }; }
   }
 
-  async resume(): Promise<RunBasicResult> {
+  async resume(pinnedFacade?: C64Facade): Promise<RunBasicResult> {
     try {
-      if (await this.shouldUseC64uMockBypass()) {
+      if (!pinnedFacade && await this.shouldUseC64uMockBypass()) {
         const res = await this.api.v1.machineResumeUpdate(":resume");
         return { success: true, details: res.data };
       }
-      const facade = await this.facadePromise; return await facade.resume();
+      const facade = pinnedFacade ?? await this.facadePromise; return await facade.resume();
     } catch (error) { return { success: false, details: this.normaliseError(error) }; }
   }
 
@@ -966,8 +1054,12 @@ export class C64Client {
    * VICE is restarted when it is managed by c64bridge.
    */
   async powerCycle(): Promise<RunBasicResult> {
+    let menuOpened = false;
+    let cleanup: RunBasicResult | undefined;
+    let pinnedFacade: C64Facade | undefined;
     try {
       const facade = await this.facadePromise;
+      pinnedFacade = facade;
       if (facade.type === "u2") {
         const result = await facade.reboot();
         return { ...result, details: { strategy: "reboot", result: result.details } };
@@ -993,6 +1085,7 @@ export class C64Client {
       if (!menuResult.success) {
         throw new Error("Unable to open the Ultimate menu for power cycling");
       }
+      menuOpened = true;
       const initial = await this.readVerifiedMenuScreen(facade, "open Ultimate menu");
       await this.requirePowerCycleInput(facade, ["f1"]);
       await this.readVerifiedMenuScreen(facade, "open Tool Menu", "TOOL MENU", initial);
@@ -1007,9 +1100,15 @@ export class C64Client {
           current,
         );
       }
+      if (!selectedMenuRowIncludes(current, "POWER CYCLE")) {
+        throw new Error("Unable to verify that POWER CYCLE is the selected Tool Menu item; final RETURN was not sent.");
+      }
       await this.requirePowerCycleInput(facade, ["return"]);
       return { success: true, details: { strategy: "tool_menu", verifiedMenu: "Tool Menu", selectedItem: "Power Cycle" } };
     } catch (error) {
+      if (menuOpened) {
+        try { cleanup = await pinnedFacade?.menuButton() ?? { success: false, details: "No facade available for menu cleanup" }; } catch (cleanupError) { cleanup = { success: false, details: this.normaliseError(cleanupError) }; }
+      }
       if (isMissingEndpoint(error)) {
         return {
           success: false,
@@ -1020,7 +1119,7 @@ export class C64Client {
           },
         };
       }
-      return { success: false, details: this.normaliseError(error) };
+      return { success: false, details: { error: this.normaliseError(error), cleanup: cleanup ?? { success: false, details: "menu cleanup was not attempted" } } };
     }
   }
 
@@ -1837,10 +1936,10 @@ export class C64Client {
    * raw binary bytes or JSON with a base64 payload.
    * Public to allow advanced polling and monitoring use cases.
    */
-  async readMemoryRaw(address: number, length: number): Promise<Uint8Array> {
+  async readMemoryRaw(address: number, length: number, pinnedFacade?: C64Facade): Promise<Uint8Array> {
     validateMemoryRange(address, length);
     try {
-      const facade = await this.facadePromise;
+      const facade = pinnedFacade ?? await this.facadePromise;
       return await facade.readMemory(address, length);
     } catch (facadeError) {
       if (!(facadeError instanceof Error) || (facadeError as any).code !== "UNSUPPORTED") {
@@ -1873,11 +1972,11 @@ export class C64Client {
    * Public so tools that need to drive cross-platform machine state (e.g.
    * keyboard-buffer injection) can avoid backend-specific paths.
    */
-  async writeMemoryRaw(address: number, bytes: Uint8Array | Buffer): Promise<void> {
+  async writeMemoryRaw(address: number, bytes: Uint8Array | Buffer, pinnedFacade?: C64Facade): Promise<void> {
     if (!Number.isInteger(address) || address < 0 || address > 0xffff) {
       throw new Error("Address must be within 0x0000 - 0xFFFF");
     }
-    const facade = await this.facadePromise;
+    const facade = pinnedFacade ?? await this.facadePromise;
     const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
     validateMemoryRange(address, buf.length);
     await facade.writeMemory(address, buf);
@@ -1903,22 +2002,24 @@ export class C64Client {
       readonly chunkSize?: number;
       readonly drainPollMs?: number;
       readonly drainTimeoutMs?: number;
+      readonly pinnedFacade?: C64Facade;
     },
-  ): Promise<void> {
+  ): Promise<{ delivered: number }> {
     const data = Buffer.isBuffer(bytes)
       ? bytes
       : Buffer.from(bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes));
     if (data.length === 0) {
-      return;
+      return { delivered: 0 };
     }
     const chunkSize = Math.max(1, Math.min(10, options?.chunkSize ?? 10));
     const pollMs = Math.max(1, options?.drainPollMs ?? 8);
     const totalTimeoutMs = Math.max(50, options?.drainTimeoutMs ?? 2000);
 
-    const facade = await this.facadePromise;
+    const facade = options?.pinnedFacade ?? await this.facadePromise;
     const KEYD = 0x0277; // KERNAL keyboard buffer base
     const NDX = 0x00C6;  // pending byte count
 
+    let delivered = 0;
     for (let offset = 0; offset < data.length; offset += chunkSize) {
       const slice = data.subarray(offset, Math.min(data.length, offset + chunkSize));
       // Write the bytes into the queue first so KERNAL never reads a stale
@@ -1926,18 +2027,24 @@ export class C64Client {
       await facade.writeMemory(KEYD, Buffer.from(slice));
       await facade.writeMemory(NDX, Buffer.from([slice.length]));
 
-      // Drain: wait for KERNAL to consume the queue. If the machine is paused
-      // or otherwise not running, give up after the timeout and continue —
-      // higher layers can decide whether that is a failure for their context.
+      // Drain before another write.  Overwriting a non-empty KERNAL queue loses
+      // user input, so a timeout is an explicit partial-delivery failure.
       const drainStart = Date.now();
+      let drained = false;
       while (Date.now() - drainStart < totalTimeoutMs) {
         const ndx = await facade.readMemory(NDX, 1);
         if ((ndx[0] ?? 0) === 0) {
+          drained = true;
           break;
         }
         await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
       }
+      delivered += slice.length;
+      if (!drained) {
+        throw new KeyboardQueueDrainTimeoutError(delivered, data.length, totalTimeoutMs);
+      }
     }
+    return { delivered };
   }
 
     async viceExitMonitor(): Promise<void> {
@@ -1951,6 +2058,10 @@ export class C64Client {
     async viceMemSet(address: number, bytes: Uint8Array | Buffer): Promise<void> {
       const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
       await this.withViceMonitor((client) => client.memSet(address, buf));
+    }
+
+    async viceJoyportSet(port: 1 | 2, activeLowMask: number): Promise<void> {
+      await this.withViceMonitor((client) => client.joyportSet(port, activeLowMask));
     }
 
     async viceMemGet(address: number, length: number): Promise<Buffer> {
@@ -2189,7 +2300,7 @@ export class C64Client {
 
   private hzToSidFrequency(hz: number, system: "PAL" | "NTSC" = "PAL"): number {
     const phi2 = system === "PAL" ? 985_248 : 1_022_727;
-    const value = Math.round((hz * 65536) / phi2);
+    const value = Math.round((hz * 16_777_216) / phi2);
     // Clamp to 16-bit
     return Math.max(0, Math.min(0xffff, value));
   }
@@ -2404,7 +2515,7 @@ function buildSingleSpriteProgram(opts: {
   return assemblyToPrg(source, { fileName: "sprite_gen.asm", loadAddress: 0x0801 });
 }
 
-function buildPetsciiScreenBasic(opts: { text: string; borderColor?: number; backgroundColor?: number }): string {
+export function buildPetsciiScreenBasic(opts: { text: string; borderColor?: number; backgroundColor?: number }): string {
   const border = toByte(opts.borderColor ?? 6); // default blue-ish
   const bg = toByte(opts.backgroundColor ?? 0); // default black
   // Clear screen, set colours, print text starting at 1,1
@@ -2413,7 +2524,7 @@ function buildPetsciiScreenBasic(opts: { text: string; borderColor?: number; bac
   const program = [
     `10 POKE 53280,${border}:POKE 53281,${bg}:PRINT CHR$(147)`,
     `20 PRINT "${sanitized}"`,
-    `30 GETA$:IFA$<>""THENEND:REM wait for key then end`,
+    `30 GETA$:IFA$=""THEN30:END:REM wait for key then end`,
   ].join("\n");
   return program;
 }
@@ -2447,11 +2558,11 @@ export function buildPrinterBasicProgram(opts: {
       ln += 10;
       continue;
     }
-    const chunks = chunkString(logical, 60);
+    const chunks = chunkString(logical, 45);
     for (let i = 0; i < chunks.length; i += 1) {
-      const chunk = escapeBasicQuotes(chunks[i]);
+      const chunk = basicStringExpression(chunks[i]);
       const tail = i < chunks.length - 1 ? ";" : ""; // avoid CR between chunks within the same logical line
-      lines.push(`${ln} PRINT#1,"${chunk}"${tail}`);
+      lines.push(`${ln} PRINT#1,${chunk}${tail}`);
       ln += 10;
     }
   }
@@ -2479,9 +2590,10 @@ function chunkString(input: string, maxLen: number): string[] {
   return parts;
 }
 
-function escapeBasicQuotes(input: string): string {
-  // In Commodore BASIC, embed a double quote by doubling it
-  return input.replace(/"/g, '""');
+function basicStringExpression(input: string): string {
+  // BASIC V2 has no doubled-quote escaping. Splice literal quote characters
+  // through CHR$(34), including leading/trailing/consecutive quote cases.
+  return input.split('"').map((part) => `"${part}"`).join(";CHR$(34);");
 }
 
 export function buildCommodoreBitmapBasicProgram(opts: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
+import os from "node:os";
 import { fileURLToPath } from "url";
 
 export interface C64BridgeConfig {
@@ -8,6 +9,13 @@ export interface C64BridgeConfig {
   c64_port: number;
   networkPassword?: string;
   vicePrewarm: boolean;
+  /** Parsed selected config document, retained so all facade construction uses
+   * the exact same authoritative source and precedence decision. */
+  backendConfig: {
+    c64u?: Record<string, unknown>;
+    u2?: Record<string, unknown>;
+    vice?: Record<string, unknown>;
+  };
 }
 
 const DEFAULT_HOST = "c64u";
@@ -18,19 +26,17 @@ const DEFAULT_CONFIG: C64BridgeConfig = {
   baseUrl: buildBaseUrl(DEFAULT_HOST, DEFAULT_PORT),
   c64_port: DEFAULT_PORT,
   vicePrewarm: false,
+  backendConfig: {},
 };
 
-let cachedConfig: C64BridgeConfig | null = null;
-
 export function loadConfig(): C64BridgeConfig {
-  if (cachedConfig) {
-    return cachedConfig;
-  }
-
   const configPath = process.env.C64BRIDGE_CONFIG;
-  const repoConfigPath = join(dirname(fileURLToPath(import.meta.url)), "..", ".c64bridge.json");
-  const homeConfigPath = process.env.HOME ? `${process.env.HOME}/.c64bridge.json` : null;
-  const candidatePaths = [configPath, repoConfigPath, homeConfigPath];
+  const cwdConfigPath = join(process.cwd(), ".c64bridge.json");
+  const homeConfigPath = join(os.homedir(), ".c64bridge.json");
+  // Legacy package-adjacent config is deliberately last: it is useful for
+  // source checkouts but must never override a project or user config.
+  const legacyPackageConfigPath = join(dirname(fileURLToPath(import.meta.url)), "..", ".c64bridge.json");
+  const candidatePaths = [configPath, cwdConfigPath, homeConfigPath, legacyPackageConfigPath];
 
   let rawConfig: any;
   for (const candidatePath of candidatePaths) {
@@ -43,7 +49,9 @@ export function loadConfig(): C64BridgeConfig {
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
+        // Deliberately omit file contents/credentials. Configuration mistakes
+        // should not prevent the MCP server from exposing a recoverable path.
+        console.error(`[c64bridge] ignoring configuration '${candidatePath}': ${error instanceof Error ? error.message : String(error)}`);
       }
     }
   }
@@ -117,9 +125,13 @@ export function loadConfig(): C64BridgeConfig {
       configuredBoolean(vice?.prewarm),
       configuredBoolean(rawConfig?.vicePrewarm),
     ) ?? false,
+    backendConfig: {
+      ...(rawConfig?.c64u && typeof rawConfig.c64u === "object" && !Array.isArray(rawConfig.c64u) ? { c64u: rawConfig.c64u } : {}),
+      ...(rawConfig?.u2 && typeof rawConfig.u2 === "object" && !Array.isArray(rawConfig.u2) ? { u2: rawConfig.u2 } : {}),
+      ...(rawConfig?.vice && typeof rawConfig.vice === "object" && !Array.isArray(rawConfig.vice) ? { vice: rawConfig.vice } : {}),
+    },
   };
 
-  cachedConfig = config;
   return config;
 }
 
@@ -206,5 +218,6 @@ function formatHost(host: string): string {
 }
 
 export function __resetConfigCacheForTests(): void {
-  cachedConfig = null;
+  // Kept as a no-op compatibility hook: config is intentionally reloaded for
+  // each construction so startup and facade creation cannot disagree.
 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -5,7 +5,6 @@
 import axios from "axios";
 import { Buffer } from "node:buffer";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { Api } from "../generated/c64/index.js";
 import type { InputBatch, InputStateResponse } from "../generated/c64/index.js";
@@ -13,6 +12,7 @@ import { createLoggingHttpClient } from "./loggingHttpClient.js";
 import { ViceClient } from "./vice/viceClient.js";
 import { waitForBasicReady } from "./vice/readiness.js";
 import { startViceProcess, type ViceProcessHandle, type ViceProcessOptions } from "./vice/process.js";
+import { loadConfig } from "./config.js";
 
 export type DeviceType = "c64u" | "u2" | "vice";
 
@@ -35,6 +35,8 @@ export interface C64Facade {
   ping(): Promise<boolean>;
   // Program runners
   runPrg(prg: Uint8Array | Buffer): Promise<RunResult>;
+  /** Load PRG bytes into memory without starting them. */
+  loadPrg(prg: Uint8Array | Buffer): Promise<RunResult>;
   loadPrgFile(path: string): Promise<RunResult>;
   runPrgFile(path: string): Promise<RunResult>;
   runCrtFile(path: string): Promise<RunResult>;
@@ -177,40 +179,12 @@ function coalesceMemoryWriteBlocks(
 }
 
 function readConfigFile(): C64BridgeConfigFile | null {
-  const envPath = process.env.C64BRIDGE_CONFIG;
-  const candidates: string[] = [];
-  if (envPath) candidates.push(envPath);
-  // Repo root
-  try {
-    const here = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", ".c64bridge.json");
-    candidates.push(here);
-  } catch {}
-  const home = process.env.HOME || os.homedir();
-  if (home) candidates.push(path.join(home, ".c64bridge.json"));
-  let foundCandidate = false;
-  const merged: C64BridgeConfigFile = {};
-  for (const p of candidates) {
-    try {
-      if (fs.existsSync(p)) {
-        foundCandidate = true;
-        const text = fs.readFileSync(p, "utf8");
-        const json = JSON.parse(text);
-        if (!merged.c64u && json?.c64u && typeof json.c64u === "object" && !Array.isArray(json.c64u)) {
-          merged.c64u = json.c64u as C64uConfig;
-        }
-        if (!merged.u2 && json?.u2 && typeof json.u2 === "object" && !Array.isArray(json.u2)) {
-          merged.u2 = json.u2 as C64uConfig;
-        }
-        if (!merged.vice && json?.vice && typeof json.vice === "object" && !Array.isArray(json.vice)) {
-          merged.vice = json.vice as ViceConfig;
-        }
-        if ((merged.c64u || merged.u2) && merged.vice) {
-          break;
-        }
-      }
-    } catch {}
-  }
-  return foundCandidate ? merged : null;
+  const sections = loadConfig().backendConfig;
+  return Object.keys(sections).length === 0 ? null : {
+    c64u: sections.c64u as C64uConfig | undefined,
+    u2: sections.u2 as C64uConfig | undefined,
+    vice: sections.vice as ViceConfig | undefined,
+  };
 }
 
 class C64uBackend implements C64Facade {
@@ -261,6 +235,15 @@ class C64uBackend implements C64Facade {
 
   getBaseUrl(): string { return this.baseUrl; }
 
+  private actionResult(data: unknown): RunResult {
+    const errors = data && typeof data === "object" && Array.isArray((data as { errors?: unknown }).errors)
+      ? (data as { errors: unknown[] }).errors.filter((error) => error !== undefined && error !== null && String(error).trim() !== "")
+      : [];
+    return errors.length > 0
+      ? { success: false, details: { response: data, errors: errors.map(String) } }
+      : { success: true, details: data };
+  }
+
   async ping(): Promise<boolean> {
     try {
       const res = await axios.get(this.baseUrl, {
@@ -274,29 +257,34 @@ class C64uBackend implements C64Facade {
   async runPrg(prg: Uint8Array | Buffer): Promise<RunResult> {
     const payload = Buffer.isBuffer(prg) ? prg : Buffer.from(prg);
     const res = await this.api.v1.runnersRunPrgCreate(":run_prg", payload as any, { headers: { "Content-Type": "application/octet-stream" } });
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
+  }
+  async loadPrg(prg: Uint8Array | Buffer): Promise<RunResult> {
+    const payload = Buffer.isBuffer(prg) ? prg : Buffer.from(prg);
+    const res = await this.api.v1.runnersLoadPrgCreate(":load_prg", payload as any, { headers: { "Content-Type": "application/octet-stream" } });
+    return this.actionResult(res.data);
   }
   async loadPrgFile(pathStr: string): Promise<RunResult> {
     const res = await this.api.v1.runnersLoadPrgUpdate(":load_prg", { file: pathStr });
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
   }
   async runPrgFile(pathStr: string): Promise<RunResult> {
     const res = await this.api.v1.runnersRunPrgUpdate(":run_prg", { file: pathStr });
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
   }
   async runCrtFile(pathStr: string): Promise<RunResult> {
     const res = await this.api.v1.runnersRunCrtUpdate(":run_crt", { file: pathStr });
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
   }
   async sidplayFile(pathStr: string, songnr?: number): Promise<RunResult> {
     const res = await this.api.v1.runnersSidplayUpdate(":sidplay", { file: pathStr, songnr });
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
   }
   async sidplayAttachment(sid: Uint8Array | Buffer, options?: { songnr?: number; songlengths?: Uint8Array | Buffer }): Promise<RunResult> {
     const form: any = { sid: Buffer.isBuffer(sid) ? sid : Buffer.from(sid) };
     if (options?.songlengths) form.songlengths = Buffer.isBuffer(options.songlengths) ? options.songlengths : Buffer.from(options.songlengths);
     const res = await this.api.v1.runnersSidplayCreate(":sidplay", form as any, options?.songnr !== undefined ? { songnr: options.songnr } : undefined);
-    return { success: true, details: res.data };
+    return this.actionResult(res.data);
   }
   async readMemory(address: number, length: number): Promise<Uint8Array> {
     const addrStr = address.toString(16).toUpperCase().padStart(4, "0");
@@ -331,13 +319,13 @@ class C64uBackend implements C64Facade {
     const mergedBlocks = coalesceMemoryWriteBlocks(blocks);
     await Promise.all(mergedBlocks.map(({ address, bytes }) => this.writeMemory(address, bytes)));
   }
-  async reset(): Promise<RunResult> { const res = await this.api.v1.machineResetUpdate(":reset"); return { success: true, details: res.data }; }
-  async reboot(): Promise<RunResult> { const res = await this.api.v1.machineRebootUpdate(":reboot"); return { success: true, details: res.data }; }
-  async pause(): Promise<RunResult> { const res = await this.api.v1.machinePauseUpdate(":pause"); return { success: true, details: res.data }; }
-  async resume(): Promise<RunResult> { const res = await this.api.v1.machineResumeUpdate(":resume"); return { success: true, details: res.data }; }
-  async poweroff(): Promise<RunResult> { this.requireC64u("poweroff"); const res = await this.api.v1.machinePoweroffUpdate(":poweroff"); return { success: true, details: res.data }; }
+  async reset(): Promise<RunResult> { const res = await this.api.v1.machineResetUpdate(":reset"); return this.actionResult(res.data); }
+  async reboot(): Promise<RunResult> { const res = await this.api.v1.machineRebootUpdate(":reboot"); return this.actionResult(res.data); }
+  async pause(): Promise<RunResult> { const res = await this.api.v1.machinePauseUpdate(":pause"); return this.actionResult(res.data); }
+  async resume(): Promise<RunResult> { const res = await this.api.v1.machineResumeUpdate(":resume"); return this.actionResult(res.data); }
+  async poweroff(): Promise<RunResult> { this.requireC64u("poweroff"); const res = await this.api.v1.machinePoweroffUpdate(":poweroff"); return this.actionResult(res.data); }
   async powerCycle(): Promise<RunResult> { this.requireC64u("powerCycle"); throw unsupported("powerCycle must be coordinated by C64Client"); }
-  async menuButton(): Promise<RunResult> { const res = await this.api.v1.machineMenuButtonUpdate(":menu_button"); return { success: true, details: res.data }; }
+  async menuButton(): Promise<RunResult> { const res = await this.api.v1.machineMenuButtonUpdate(":menu_button"); return this.actionResult(res.data); }
   async readMenuScreen(): Promise<Uint8Array> {
     const response = await this.api.v1.machineMenuScreenList(
       ":menu_screen",
@@ -360,29 +348,42 @@ class C64uBackend implements C64Facade {
   async debugregWrite(value: string): Promise<{ success: boolean; value?: string; details?: unknown }> { this.requireC64u("debugregWrite"); const res = await this.api.v1.machineDebugregUpdate(":debugreg", { value }); return { success: true, value: (res.data as any).value, details: res.data }; }
   async version(): Promise<unknown> { const res = await this.api.v1.versionList(); return res.data; }
   async info(): Promise<unknown> { const res = await this.api.v1.infoList(); return res.data; }
-  async drivesList(): Promise<unknown> { const res = await this.api.v1.drivesList(); return res.data; }
-  async driveMount(d: string, img: string, options?: { type?: "d64" | "g64" | "d71" | "g71" | "d81"; mode?: "readwrite" | "readonly" | "unlinked" }): Promise<RunResult> { const res = await this.api.v1.drivesMountUpdate(d, ":mount", { image: img, type: options?.type, mode: options?.mode }); return { success: true, details: res.data }; }
-  async driveRemove(d: string): Promise<RunResult> { const res = await this.api.v1.drivesRemoveUpdate(d, ":remove"); return { success: true, details: res.data }; }
-  async driveReset(d: string): Promise<RunResult> { const res = await this.api.v1.drivesResetUpdate(d, ":reset"); return { success: true, details: res.data }; }
-  async driveOn(d: string): Promise<RunResult> { const res = await this.api.v1.drivesOnUpdate(d, ":on"); return { success: true, details: res.data }; }
-  async driveOff(d: string): Promise<RunResult> { const res = await this.api.v1.drivesOffUpdate(d, ":off"); return { success: true, details: res.data }; }
-  async driveSetMode(d: string, mode: "1541" | "1571" | "1581"): Promise<RunResult> { const res = await this.api.v1.drivesSetModeUpdate(d, ":set_mode", { mode }); return { success: true, details: res.data }; }
-  async driveLoadRom(d: string, romPath: string): Promise<RunResult> { const res = await this.api.v1.drivesLoadRomUpdate(d, ":load_rom", { file: romPath }); return { success: true, details: res.data }; }
-  async streamStart(s: "video" | "audio" | "debug", ip: string): Promise<RunResult> { this.requireC64u("streamStart"); const res = await this.api.v1.streamsStartUpdate(s, ":start", { ip }); return { success: true, details: res.data }; }
-  async streamStop(s: "video" | "audio" | "debug"): Promise<RunResult> { this.requireC64u("streamStop"); const res = await this.api.v1.streamsStopUpdate(s, ":stop"); return { success: true, details: res.data }; }
+  async drivesList(): Promise<unknown> {
+    const res = await this.api.v1.drivesList();
+    const raw = res.data as { drives?: Array<Record<string, Record<string, unknown>>> | Record<string, Record<string, unknown>> };
+    const entries = Array.isArray(raw.drives)
+      ? raw.drives
+      : raw.drives && typeof raw.drives === "object" ? [raw.drives] : [];
+    return entries.flatMap((entry) => Object.entries(entry).map(([id, info]) => ({
+      id,
+      power: info.enabled === true || info.enabled === "on" || info.power === "on" ? "on" : "off",
+      image: (info.image_path ?? info.image_file ?? info.image ?? null) as string | null,
+      type: info.type ?? null,
+      raw: info,
+    })));
+  }
+  async driveMount(d: string, img: string, options?: { type?: "d64" | "g64" | "d71" | "g71" | "d81"; mode?: "readwrite" | "readonly" | "unlinked" }): Promise<RunResult> { const res = await this.api.v1.drivesMountUpdate(d, ":mount", { image: img, type: options?.type, mode: options?.mode }); return this.actionResult(res.data); }
+  async driveRemove(d: string): Promise<RunResult> { const res = await this.api.v1.drivesRemoveUpdate(d, ":remove"); return this.actionResult(res.data); }
+  async driveReset(d: string): Promise<RunResult> { const res = await this.api.v1.drivesResetUpdate(d, ":reset"); return this.actionResult(res.data); }
+  async driveOn(d: string): Promise<RunResult> { const res = await this.api.v1.drivesOnUpdate(d, ":on"); return this.actionResult(res.data); }
+  async driveOff(d: string): Promise<RunResult> { const res = await this.api.v1.drivesOffUpdate(d, ":off"); return this.actionResult(res.data); }
+  async driveSetMode(d: string, mode: "1541" | "1571" | "1581"): Promise<RunResult> { const res = await this.api.v1.drivesSetModeUpdate(d, ":set_mode", { mode }); return this.actionResult(res.data); }
+  async driveLoadRom(d: string, romPath: string): Promise<RunResult> { const res = await this.api.v1.drivesLoadRomUpdate(d, ":load_rom", { file: romPath }); return this.actionResult(res.data); }
+  async streamStart(s: "video" | "audio" | "debug", ip: string): Promise<RunResult> { this.requireC64u("streamStart"); const res = await this.api.v1.streamsStartUpdate(s, ":start", { ip }); return this.actionResult(res.data); }
+  async streamStop(s: "video" | "audio" | "debug"): Promise<RunResult> { this.requireC64u("streamStop"); const res = await this.api.v1.streamsStopUpdate(s, ":stop"); return this.actionResult(res.data); }
   async configsList(): Promise<unknown> { const res = await this.api.v1.configsList(); return res.data; }
   async configGet(cat: string, item?: string): Promise<unknown> { const res = item ? await this.api.v1.configsDetail2(cat, item) : await this.api.v1.configsDetail(cat); return res.data; }
-  async configSet(cat: string, item: string, value: string): Promise<RunResult> { const res = await this.api.v1.configsUpdate(cat, item, { value }); return { success: true, details: res.data }; }
-  async configBatchUpdate(payload: Record<string, object>): Promise<RunResult> { const res = await this.api.v1.configsCreate(payload); return { success: true, details: res.data }; }
-  async configLoadFromFlash(): Promise<RunResult> { const res = await this.api.v1.configsLoadFromFlashUpdate(":load_from_flash"); return { success: true, details: res.data }; }
-  async configSaveToFlash(): Promise<RunResult> { const res = await this.api.v1.configsSaveToFlashUpdate(":save_to_flash"); return { success: true, details: res.data }; }
-  async configResetToDefault(): Promise<RunResult> { const res = await this.api.v1.configsResetToDefaultUpdate(":reset_to_default"); return { success: true, details: res.data }; }
-  async filesInfo(p: string): Promise<unknown> { const res = await this.api.v1.filesInfoDetail(encodeURIComponent(p), ":info"); return res.data; }
-  async filesCreateD64(p: string, options?: { tracks?: 35 | 40; diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD64Update(encodeURIComponent(p), ":create_d64", { tracks: options?.tracks, diskname: options?.diskname }); return { success: true, details: res.data }; }
-  async filesCreateD71(p: string, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD71Update(encodeURIComponent(p), ":create_d71", { diskname: options?.diskname }); return { success: true, details: res.data }; }
-  async filesCreateD81(p: string, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD81Update(encodeURIComponent(p), ":create_d81", { diskname: options?.diskname }); return { success: true, details: res.data }; }
-  async filesCreateDnp(p: string, tracks: number, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateDnpUpdate(encodeURIComponent(p), ":create_dnp", { tracks, diskname: options?.diskname }); return { success: true, details: res.data }; }
-  async modplayFile(pathStr: string): Promise<RunResult> { const res = await (this.api as any).v1.runnersModplayUpdate(":modplay", { file: pathStr }); return { success: true, details: res.data }; }
+  async configSet(cat: string, item: string, value: string): Promise<RunResult> { const res = await this.api.v1.configsUpdate(cat, item, { value }); return this.actionResult(res.data); }
+  async configBatchUpdate(payload: Record<string, object>): Promise<RunResult> { const res = await this.api.v1.configsCreate(payload); return this.actionResult(res.data); }
+  async configLoadFromFlash(): Promise<RunResult> { const res = await this.api.v1.configsLoadFromFlashUpdate(":load_from_flash"); return this.actionResult(res.data); }
+  async configSaveToFlash(): Promise<RunResult> { const res = await this.api.v1.configsSaveToFlashUpdate(":save_to_flash"); return this.actionResult(res.data); }
+  async configResetToDefault(): Promise<RunResult> { const res = await this.api.v1.configsResetToDefaultUpdate(":reset_to_default"); return this.actionResult(res.data); }
+  async filesInfo(p: string): Promise<unknown> { const res = await this.api.v1.filesInfoDetail(encodeDevicePath(p), ":info"); return res.data; }
+  async filesCreateD64(p: string, options?: { tracks?: 35 | 40; diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD64Update(encodeDevicePath(p), ":create_d64", { tracks: options?.tracks, diskname: options?.diskname }); return this.actionResult(res.data); }
+  async filesCreateD71(p: string, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD71Update(encodeDevicePath(p), ":create_d71", { diskname: options?.diskname }); return this.actionResult(res.data); }
+  async filesCreateD81(p: string, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateD81Update(encodeDevicePath(p), ":create_d81", { diskname: options?.diskname }); return this.actionResult(res.data); }
+  async filesCreateDnp(p: string, tracks: number, options?: { diskname?: string }): Promise<RunResult> { const res = await this.api.v1.filesCreateDnpUpdate(encodeDevicePath(p), ":create_dnp", { tracks, diskname: options?.diskname }); return this.actionResult(res.data); }
+  async modplayFile(pathStr: string): Promise<RunResult> { const res = await (this.api as any).v1.runnersModplayUpdate(":modplay", { file: pathStr }); return this.actionResult(res.data); }
 }
 
 export class ViceBackend implements C64Facade {
@@ -554,13 +555,19 @@ export class ViceBackend implements C64Facade {
       return;
     }
     ViceBackend.cleanupRegistered = true;
-    /* c8 ignore next 5 -- global process exit hooks are not practical to exercise in the unit test process */
-    process.once("exit", () => {
+    const cleanupSync = () => {
       for (const [, handle] of ViceBackend.supervisors) {
-        handle.stop().catch(() => {});
+        handle.stopSync();
       }
       ViceBackend.supervisors.clear();
-    });
+    };
+    process.once("exit", cleanupSync);
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+      process.once(signal, () => {
+        cleanupSync();
+        process.exit(signal === "SIGINT" ? 130 : 143);
+      });
+    }
   }
 
   private async withClient<T>(fn: (client: ViceClient) => Promise<T>, options?: { resumeOnClose?: boolean }): Promise<T> {
@@ -622,7 +629,18 @@ export class ViceBackend implements C64Facade {
     return false;
   }
 
-  private async injectPrg(buffer: Buffer): Promise<void> {
+  /**
+   * Reset, wait for a usable BASIC prompt, and load PRG bytes into memory.
+   * `finish` decides what happens next: a genuine BASIC PRG needs its
+   * pointers set and RUN typed, but machine code must never receive either
+   * — RUN would misinterpret raw opcodes as tokenized BASIC text, and
+   * rewriting TXTTAB/VARTAB/ARYTAB/STREND corrupts the BASIC workspace for
+   * an origin that isn't BASIC program text at all.
+   */
+  private async loadPrgAndFinish(
+    buffer: Buffer,
+    finish: (client: ViceClient, loadAddress: number, programEnd: number) => Promise<void>,
+  ): Promise<void> {
     if (buffer.length < 2) throw new Error("PRG data too short");
     const loadAddress = buffer.readUInt16LE(0);
     const body = buffer.subarray(2);
@@ -630,7 +648,13 @@ export class ViceBackend implements C64Facade {
       await client.reset();
       await waitForBasicReady(client, { timeoutMs: 10_000, ensurePrompt: true });
       if (body.length > 0) await client.memSet(loadAddress, body);
-      const programEnd = loadAddress + body.length;
+      await finish(client, loadAddress, loadAddress + body.length);
+      await client.exitMonitor();
+    });
+  }
+
+  private async injectPrg(buffer: Buffer): Promise<void> {
+    await this.loadPrgAndFinish(buffer, async (client, loadAddress, programEnd) => {
       const ptrs = Buffer.alloc(8);
       ptrs.writeUInt16LE(loadAddress, 0);
       ptrs.writeUInt16LE(programEnd, 2);
@@ -638,13 +662,20 @@ export class ViceBackend implements C64Facade {
       ptrs.writeUInt16LE(programEnd, 6);
       await client.memSet(0x002B, ptrs);
       await client.keyboardFeed("RUN\r");
-      await client.exitMonitor();
     });
   }
 
   async runPrg(prg: Uint8Array | Buffer): Promise<RunResult> {
     const buffer = Buffer.isBuffer(prg) ? prg : Buffer.from(prg);
     await this.injectPrg(buffer);
+    return { success: true };
+  }
+
+  /** Load PRG bytes without starting them — the caller decides how to enter
+   * the code (e.g. a subsequent typed `SYS <entry>` for machine code). */
+  async loadPrg(prg: Uint8Array | Buffer): Promise<RunResult> {
+    const buffer = Buffer.isBuffer(prg) ? prg : Buffer.from(prg);
+    await this.loadPrgAndFinish(buffer, async () => {});
     return { success: true };
   }
 
@@ -695,21 +726,28 @@ export class ViceBackend implements C64Facade {
   }
 
   async reset(): Promise<RunResult> {
+    let readiness: Awaited<ReturnType<typeof waitForBasicReady>> | undefined;
+    // Overridable only for deterministic tests of the readiness-failure path;
+    // production always uses the 20s default.
+    const resetReadinessTimeoutMs = Number(process.env.C64BRIDGE_VICE_RESET_TIMEOUT_MS) || 20_000;
     await this.withClient(async (client) => {
       await client.reset();
       const opts = this.debugEnabled
         ? {
-            timeoutMs: 20_000,
+            timeoutMs: resetReadinessTimeoutMs,
             ensurePrompt: true,
             onPointersSample: (p: { tx: number; va: number; ar: number; st: number }) => {
               console.error("[vice-backend] BASIC pointers", p);
             },
           }
-        : { timeoutMs: 20_000, ensurePrompt: true };
-      const readiness = await waitForBasicReady(client, opts);
+        : { timeoutMs: resetReadinessTimeoutMs, ensurePrompt: true };
+      readiness = await waitForBasicReady(client, opts);
       if (this.debugEnabled) console.error("[vice-backend] waitForBasicReady result", readiness);
     });
-    return { success: true };
+    const ready = Boolean(readiness?.pointersOk && readiness?.promptOk);
+    return ready
+      ? { success: true, details: readiness }
+      : { success: false, details: { readiness, message: "VICE reset completed but BASIC READY was not observed. Reset again or inspect the emulator monitor." } };
   }
 
   async reboot(): Promise<RunResult> { return this.reset(); }
@@ -906,9 +944,11 @@ export class ViceBackend implements C64Facade {
   }
 
   async configSet(_category: string, item: string, value: string): Promise<RunResult> {
-    const numValue = Number(value);
-    const parsed: string | number = !isNaN(numValue) && value.trim() !== "" ? numValue : value;
+    let parsed: string | number = value;
     await this.withClient(async (client) => {
+      const current = await client.resourceGet(item);
+      parsed = current.type === "int" ? Number(value) : value;
+      if (current.type === "int" && !Number.isFinite(parsed)) throw new Error(`VICE resource '${item}' requires an integer value`);
       await client.resourceSet(item, parsed);
     });
     return { success: true, details: { item, value: parsed } };
@@ -921,8 +961,9 @@ export class ViceBackend implements C64Facade {
         for (const [item, value] of Object.entries(items as Record<string, unknown>)) {
           try {
             const str = String(value ?? "");
-            const numValue = Number(str);
-            const parsed: string | number = !isNaN(numValue) && str.trim() !== "" ? numValue : str;
+            const current = await client.resourceGet(item);
+            const parsed: string | number = current.type === "int" ? Number(str) : str;
+            if (current.type === "int" && !Number.isFinite(parsed)) throw new Error(`VICE resource '${item}' requires an integer value`);
             await client.resourceSet(item, parsed);
             results.push({ item: `${category}/${item}`, success: true });
           } catch (err) {
@@ -948,6 +989,12 @@ export class ViceBackend implements C64Facade {
 }
 
 function unsupported(name: string): Error { const err = new Error(`Operation '${name}' is not supported by the VICE backend in phase one`); (err as any).code = "UNSUPPORTED"; return err; }
+
+/** Ultimate file APIs treat slash as a path separator. Encode each name once,
+ * preserving leading and nested separators for firmware routing. */
+function encodeDevicePath(value: string): string {
+  return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
 
 function parseDriveNumber(drive: string): number {
   const match = /\d+/.exec(drive);

--- a/src/knowledge.ts
+++ b/src/knowledge.ts
@@ -97,7 +97,7 @@ Key SID Registers (decimal addresses):
 **PAL vs NTSC Clock Differences:**
 - PAL: 985,248 Hz SID clock
 - NTSC: 1,022,727 Hz SID clock
-- Formula: freq_value = (frequency_Hz × 65536) / clock_rate
+- Formula: freq_value = round((frequency_Hz × 16777216) / clock_rate) (SID has a 24-bit phase accumulator)
 
 **Complete SID Frequency Lookup Table (All Notes, Multiple Octaves):**
 

--- a/src/loggingHttpClient.ts
+++ b/src/loggingHttpClient.ts
@@ -11,6 +11,18 @@ type RequestMeta = {
   body?: unknown;
 };
 
+/** Headers are useful in diagnostics, but credentials must never leave the
+ * transport layer.  Axios normalises some keys and preserves others, so do a
+ * case-insensitive pass instead of relying on one spelling. */
+function redactHeaders(headers: AxiosRequestConfig["headers"] | undefined): AxiosRequestConfig["headers"] | undefined {
+  if (!headers) return headers;
+  const sensitive = /^(x-password|authorization|proxy-authorization|cookie|set-cookie|x-api-key)$/i;
+  return Object.fromEntries(Object.entries(headers as Record<string, unknown>).map(([key, value]) => [
+    key,
+    sensitive.test(key) ? "***" : value,
+  ])) as AxiosRequestConfig["headers"];
+}
+
 export function createLoggingHttpClient<SecurityDataType = unknown>(
   config?: ApiConfig<SecurityDataType>,
   logger: PrefixedLogger = loggerFor("c64u"),
@@ -25,7 +37,7 @@ export function createLoggingHttpClient<SecurityDataType = unknown>(
       startedAt: Date.now(),
       method,
       path,
-      headers: request.headers ? { ...request.headers } : undefined,
+      headers: redactHeaders(request.headers),
       params: request.params ? { ...request.params } : undefined,
       body: request.data,
     };
@@ -65,7 +77,7 @@ function handleResponse(response: AxiosResponse, logger: PrefixedLogger): void {
     });
     logger.debug(`response ${method} ${path}`, {
       status: response.status,
-      headers: response.headers ?? {},
+      headers: redactHeaders(response.headers),
       body: formatPayloadForDebug(response.data),
     });
   }
@@ -97,7 +109,7 @@ function handleError(error: AxiosError, logger: PrefixedLogger): void {
     });
     logger.debug(`error ${method} ${path}`, {
       status,
-      headers: response?.headers ?? {},
+      headers: redactHeaders(response?.headers),
       body: response ? formatPayloadForDebug(response.data) : null,
       message,
     });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -57,7 +57,7 @@ function createPromptRegistryGetter() {
   };
 }
 
-function parseCliOptions(argv: string[]): CliOptions {
+export function parseCliOptions(argv: string[]): CliOptions {
   const httpIndex = argv.indexOf("--http");
   if (httpIndex === -1) {
     return { mode: "stdio" };
@@ -489,14 +489,34 @@ async function main() {
     }
   });
 
-  // Connect via stdio
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  writeDiagnosticEvent("mcp_transport_connected", { mode: "stdio" });
+  const cli = parseCliOptions(process.argv.slice(2));
+  if (cli.mode === "http") {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await server.connect(transport);
+    const port = cli.port ?? 3000;
+    const httpServer = createServer((request, response) => {
+      if (request.url?.split("?")[0] !== "/mcp") {
+        response.statusCode = 404;
+        response.end("Not found");
+        return;
+      }
+      void transport.handleRequest(request, response).catch((error) => {
+        if (!response.headersSent) response.statusCode = 500;
+        response.end(error instanceof Error ? error.message : "MCP transport error");
+      });
+    });
+    await new Promise<void>((resolve, reject) => httpServer.listen(port, "127.0.0.1", resolve).once("error", reject));
+    writeDiagnosticEvent("mcp_transport_connected", { mode: "http", port });
+    console.error(`c64bridge MCP server running on HTTP at http://127.0.0.1:${port}/mcp`);
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    writeDiagnosticEvent("mcp_transport_connected", { mode: "stdio" });
+    console.error("c64bridge MCP server running on stdio");
+  }
 
   await logConnectivity(client, baseUrl);
   
-  console.error("c64bridge MCP server running on stdio");
   writeDiagnosticEvent("server_ready", {
     diagnosticsFile: diagnostics.filePath,
   });
@@ -520,11 +540,18 @@ function createPlatformResourceDescriptor() {
   };
 }
 
-async function renderPlatformStatusMarkdown(client: C64Client): Promise<string> {
+export async function renderPlatformStatusMarkdown(client: C64Client): Promise<string> {
   const status = getPlatformStatus();
   const availableBackends = client.getAvailableBackends();
   const capabilities = describePlatformCapabilities(toolRegistry.list());
-  const nativeEndpoints = await client.getNativeEndpointCapabilities();
+  // Resource reads must remain responsive while an Ultimate boots or is
+  // unreachable. The probe itself remains retryable (unknown is not cached).
+  const nativeEndpoints = await Promise.race([
+    client.getNativeEndpointCapabilities(),
+    new Promise<Awaited<ReturnType<C64Client["getNativeEndpointCapabilities"]>>>((resolve) => {
+      setTimeout(() => resolve({ machineInput: "unknown", machineMenuScreen: "unknown" }), 750);
+    }),
+  ]);
 
   const lines: string[] = [
     "# MCP Platform Status",
@@ -691,11 +718,21 @@ function toPromptMessage(segment: PromptSegment): {
   };
 }
 
-main().catch((error) => {
-  writeDiagnosticEvent("server_fatal", {
-    diagnosticsFile: getDiagnosticsSessionInfo()?.filePath,
-    error,
+// The documented entrypoint (src/index.ts / dist/index.js, per package.json
+// "main"/"bin") always imports this module as a side effect rather than
+// invoking it as the process's own script, so process.argv[1] never points
+// here — an entrypoint-identity check would wrongly skip startup in every
+// real deployment. Test code that only needs a pure export (e.g.
+// parseCliOptions, renderPlatformStatusMarkdown) sets this opt-out instead,
+// mirroring the existing C64BRIDGE_START_SKIP_AUTO_LAUNCH convention in
+// scripts/start.mjs.
+if (process.env.C64BRIDGE_SKIP_AUTO_START !== "1") {
+  main().catch((error) => {
+    writeDiagnosticEvent("server_fatal", {
+      diagnosticsFile: getDiagnosticsSessionInfo()?.filePath,
+      error,
+    });
+    console.error("Fatal error in MCP server:", error);
+    process.exit(1);
   });
-  console.error("Fatal error in MCP server:", error);
-  process.exit(1);
-});
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -549,7 +549,7 @@ export async function renderPlatformStatusMarkdown(client: C64Client): Promise<s
   const nativeEndpoints = await Promise.race([
     client.getNativeEndpointCapabilities(),
     new Promise<Awaited<ReturnType<C64Client["getNativeEndpointCapabilities"]>>>((resolve) => {
-      setTimeout(() => resolve({ machineInput: "unknown", machineMenuScreen: "unknown" }), 750);
+      setTimeout(() => resolve({ machineInput: "unknown", machineMenuScreen: "unknown" }), 750).unref();
     }),
   ]);
 

--- a/src/rag/indexer.ts
+++ b/src/rag/indexer.ts
@@ -5,19 +5,22 @@ GPL-2.0-only
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { EmbeddingIndexFile, EmbeddingRecord, RagLanguage } from "./types.js";
 import fsSync from "node:fs";
 import { EmbeddingModel } from "./embeddings.js";
 
-const BASIC_DIR = path.resolve("data/basic/examples");
-const ASM_DIR = path.resolve("data/assembly/examples");
-const EXTERNAL_DIR = path.resolve("external");
-const DOC_ROOT = path.resolve("doc");
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ASSET_ROOT = process.env.C64BRIDGE_ASSET_ROOT ? path.resolve(process.env.C64BRIDGE_ASSET_ROOT) : PACKAGE_ROOT;
+const BASIC_DIR = path.join(ASSET_ROOT, "data/basic/examples");
+const ASM_DIR = path.join(ASSET_ROOT, "data/assembly/examples");
+const EXTERNAL_DIR = path.join(ASSET_ROOT, "external");
+const DOC_ROOT = path.join(ASSET_ROOT, "doc");
 const DOC_EXCLUDE_DIRS = new Set(["plans"]);
-const CONTEXT_DIR = path.resolve("data/context");
+const CONTEXT_DIR = path.join(ASSET_ROOT, "data/context");
 const BOOTSTRAP_PATH = path.join(CONTEXT_DIR, "bootstrap.md");
-const AGENTS_PATH = path.resolve("AGENTS.md");
-const PROMPTS_DIR = path.resolve(".github/prompts");
+const AGENTS_PATH = path.join(ASSET_ROOT, "AGENTS.md");
+const PROMPTS_DIR = path.join(ASSET_ROOT, ".github/prompts");
 const CHAT_PATH = path.join(CONTEXT_DIR, "chat.md");
 // RAG_DOC_FILES env var can add extra specific files, comma-separated
 const ENV_DOC_FILES = (process.env.RAG_DOC_FILES ?? "")
@@ -40,7 +43,7 @@ function shouldExcludeDocFile(file: string): boolean {
 }
 
 function resolveEmbeddingsDir(override?: string): string {
-  return path.resolve(override ?? process.env.RAG_EMBEDDINGS_DIR ?? "data");
+  return path.resolve(override ?? process.env.RAG_EMBEDDINGS_DIR ?? path.join(ASSET_ROOT, "data"));
 }
 
 function embeddingIndexPaths(dir: string) {

--- a/src/rag/init.ts
+++ b/src/rag/init.ts
@@ -5,24 +5,27 @@ GPL-2.0-only
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 import { LocalMiniHashEmbedding } from "./embeddings.js";
 import { buildAllIndexes, loadIndexes } from "./indexer.js";
 import { LocalRagRetriever } from "./retriever.js";
 import { LoggingRagRetriever } from "./loggingRetriever.js";
 import type { RagRetriever } from "./types.js";
-const EXTERNAL_DIR = path.resolve("external");
-const BASIC_DATA_DIR = path.resolve("data/basic/examples");
-const ASM_DATA_DIR = path.resolve("data/assembly/examples");
-const DOC_DIR = path.resolve("doc");
-const CONTEXT_DIR = path.resolve("data/context");
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const assetRoot = process.env.C64BRIDGE_ASSET_ROOT ? path.resolve(process.env.C64BRIDGE_ASSET_ROOT) : PACKAGE_ROOT;
+const EXTERNAL_DIR = path.join(assetRoot, "external");
+const BASIC_DATA_DIR = path.join(assetRoot, "data/basic/examples");
+const ASM_DATA_DIR = path.join(assetRoot, "data/assembly/examples");
+const DOC_DIR = path.join(assetRoot, "doc");
+const CONTEXT_DIR = path.join(assetRoot, "data/context");
 const BOOTSTRAP_PATH = path.join(CONTEXT_DIR, "bootstrap.md");
-const AGENTS_PATH = path.resolve("AGENTS.md");
-const PROMPTS_DIR = path.resolve(".github/prompts");
+const AGENTS_PATH = path.join(assetRoot, "AGENTS.md");
+const PROMPTS_DIR = path.join(assetRoot, ".github/prompts");
 const CHAT_PATH = path.join(CONTEXT_DIR, "chat.md");
 
 function resolveEmbeddingsDir(): string {
-  return path.resolve(process.env.RAG_EMBEDDINGS_DIR ?? "data");
+  return path.resolve(process.env.RAG_EMBEDDINGS_DIR ?? path.join(assetRoot, "data"));
 }
 
 function embeddingIndexPaths() {

--- a/src/sidwaveCompiler.ts
+++ b/src/sidwaveCompiler.ts
@@ -187,9 +187,9 @@ export function compileSidwaveToSid(doc: ParsedSidwave, prg: Buffer, options?: {
   return { sid: Buffer.concat([header, body]) };
 }
 
-function hzToSidFrequency(hz: number, system: SystemMode): number {
+export function hzToSidFrequency(hz: number, system: SystemMode): number {
   const phi2 = system === "PAL" ? 985_248 : 1_022_727;
-  const value = Math.round((hz * 65536) / phi2);
+  const value = Math.round((hz * 16_777_216) / phi2);
   return Math.max(0, Math.min(0xffff, value));
 }
 

--- a/src/tools/audio.ts
+++ b/src/tools/audio.ts
@@ -24,6 +24,12 @@ const NOTE_PATTERN = /^([A-Ga-g])([#b]?)(-?\d+)$/;
 const DEFAULT_SILENCE_VERIFY_DURATION_SECONDS = 1.5;
 const DEFAULT_SILENCE_VERIFY_RMS_THRESHOLD = 0.02;
 const DEFAULT_SILENCE_VERIFY_WAIT_MS = 150;
+const generatedPlaybacks = new Set<AbortController>();
+
+export function cancelGeneratedSidPlayback(): void {
+  for (const controller of generatedPlaybacks) controller.abort();
+  generatedPlaybacks.clear();
+}
 
 function toRecord(details: unknown): Record<string, unknown> | undefined {
   if (details && typeof details === "object") {
@@ -524,6 +530,9 @@ export const audioModule = defineToolModule({
           const parsed = sidResetArgsSchema.parse(args ?? {});
           ctx.logger.info("Resetting SID", { mode: parsed.hard ? "hard" : "soft" });
 
+          // A reset is the documented way to stop a generated arpeggio; without
+          // this, the detached loop would keep writing notes after the reset.
+          cancelGeneratedSidPlayback();
           const result = await ctx.client.sidReset(parsed.hard);
           if (!result.success) {
             throw new ToolExecutionError("C64 firmware reported failure while resetting SID", {
@@ -680,6 +689,9 @@ export const audioModule = defineToolModule({
 
           ctx.logger.info("Silencing all SID voices", { verify });
 
+          // Stop any generated arpeggio; otherwise its remaining notes would
+          // resume writing right after this silences the chip.
+          cancelGeneratedSidPlayback();
           const result = await ctx.client.sidSilenceAll();
           if (!result.success) {
             throw new ToolExecutionError("C64 firmware reported failure while silencing SID", {
@@ -887,10 +899,22 @@ export const audioModule = defineToolModule({
             waveform: parsed.waveform,
           });
 
+          // Replace any prior generated arpeggio; it is explicitly scheduled
+          // work, never a detached operation that may retarget a later backend.
+          cancelGeneratedSidPlayback();
+          const controller = new AbortController();
+          generatedPlaybacks.add(controller);
+          // Pin the facade once at creation: even if c64_select_backend runs
+          // while this loop is still stepping through notes, every remaining
+          // note must keep targeting the backend that was active when this
+          // arpeggio was scheduled (HARD01-030).
+          const pinnedFacadePromise = ctx.client.pinFacade ? ctx.client.pinFacade() : Promise.resolve(undefined);
           void (async () => {
             try {
-              await ctx.client.sidSetVolume(8);
+              const pinnedFacade = await pinnedFacadePromise;
+              await ctx.client.sidSetVolume(8, pinnedFacade);
               for (let i = 0; i < parsed.steps; i += 1) {
+                if (controller.signal.aborted) break;
                 const iv = intervals[i % intervals.length]!;
                 const note = transposeNote(parsed.root, iv);
                 await ctx.client.sidNoteOn({
@@ -902,18 +926,23 @@ export const audioModule = defineToolModule({
                   decay: 7,
                   sustain: 15,
                   release: 0,
-                });
+                }, pinnedFacade);
                 const durationMs = parsed.preset === "expression" ? expressiveDurations[i % expressiveDurations.length]! : parsed.tempoMs;
-                await sleep(durationMs);
+                // Clear GATE between notes so every note retriggers ADSR.
+                await sleep(Math.max(1, Math.min(20, Math.floor(durationMs / 8))));
+                await ctx.client.sidNoteOff(1, pinnedFacade);
+                if (!controller.signal.aborted) await sleep(Math.max(0, durationMs - Math.max(1, Math.min(20, Math.floor(durationMs / 8)))));
               }
-              await ctx.client.sidNoteOff(1);
+              await ctx.client.sidNoteOff(1, pinnedFacade);
             } catch (playbackError) {
               const message = playbackError instanceof Error ? playbackError.message : String(playbackError);
               ctx.logger.warn("music_generate playback failed", { error: message });
+            } finally {
+              generatedPlaybacks.delete(controller);
             }
           })();
 
-          return textResult(`Scheduled ${parsed.steps} note arpeggio starting on ${parsed.root}.`, {
+          return textResult(`Scheduled ${parsed.steps} note arpeggio starting on ${parsed.root}. Playback is running and will be replaced by the next generated sequence.`, {
             success: true,
             root: parsed.root,
             intervals,

--- a/src/tools/audio.ts
+++ b/src/tools/audio.ts
@@ -530,9 +530,7 @@ export const audioModule = defineToolModule({
           const parsed = sidResetArgsSchema.parse(args ?? {});
           ctx.logger.info("Resetting SID", { mode: parsed.hard ? "hard" : "soft" });
 
-          // A reset is the documented way to stop a generated arpeggio; without
-          // this, the detached loop would keep writing notes after the reset.
-          cancelGeneratedSidPlayback();
+          cancelGeneratedSidPlayback(); // Reset is the documented way to stop a generated arpeggio.
           const result = await ctx.client.sidReset(parsed.hard);
           if (!result.success) {
             throw new ToolExecutionError("C64 firmware reported failure while resetting SID", {
@@ -689,9 +687,7 @@ export const audioModule = defineToolModule({
 
           ctx.logger.info("Silencing all SID voices", { verify });
 
-          // Stop any generated arpeggio; otherwise its remaining notes would
-          // resume writing right after this silences the chip.
-          cancelGeneratedSidPlayback();
+          cancelGeneratedSidPlayback(); // Otherwise its remaining notes would resume writing right after this silences the chip.
           const result = await ctx.client.sidSilenceAll();
           if (!result.success) {
             throw new ToolExecutionError("C64 firmware reported failure while silencing SID", {
@@ -899,16 +895,10 @@ export const audioModule = defineToolModule({
             waveform: parsed.waveform,
           });
 
-          // Replace any prior generated arpeggio; it is explicitly scheduled
-          // work, never a detached operation that may retarget a later backend.
-          cancelGeneratedSidPlayback();
+          cancelGeneratedSidPlayback(); // Replace any prior generated arpeggio rather than letting two run at once.
           const controller = new AbortController();
           generatedPlaybacks.add(controller);
-          // Pin the facade once at creation: even if c64_select_backend runs
-          // while this loop is still stepping through notes, every remaining
-          // note must keep targeting the backend that was active when this
-          // arpeggio was scheduled (HARD01-030).
-          const pinnedFacadePromise = ctx.client.pinFacade ? ctx.client.pinFacade() : Promise.resolve(undefined);
+          const pinnedFacadePromise = ctx.client.pinFacade ? ctx.client.pinFacade() : Promise.resolve(undefined); // Pin once so a later select_backend can't retarget notes mid-arpeggio (HARD01-030).
           void (async () => {
             try {
               const pinnedFacade = await pinnedFacadePromise;
@@ -928,8 +918,7 @@ export const audioModule = defineToolModule({
                   release: 0,
                 }, pinnedFacade);
                 const durationMs = parsed.preset === "expression" ? expressiveDurations[i % expressiveDurations.length]! : parsed.tempoMs;
-                // Clear GATE between notes so every note retriggers ADSR.
-                await sleep(Math.max(1, Math.min(20, Math.floor(durationMs / 8))));
+                await sleep(Math.max(1, Math.min(20, Math.floor(durationMs / 8)))); // Clear GATE between notes so every note retriggers ADSR.
                 await ctx.client.sidNoteOff(1, pinnedFacade);
                 if (!controller.signal.aborted) await sleep(Math.max(0, durationMs - Math.max(1, Math.min(20, Math.floor(durationMs / 8)))));
               }

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -116,13 +116,9 @@ function expandPetsciiTokens(text: string): string {
 
 // ---------------------------------------------------------------------------
 // Joystick helpers
-// Port 2 → CIA1 Port A ($DC00), Port 1 → CIA1 Port B ($DC01)
-// Bits 0-4: Up / Down / Left / Right / Fire, active LOW (0 = pressed)
+// Bits 0-4: Up / Down / Left / Right / Fire, active LOW (0 = pressed).
+// VICE must use Binary Monitor Joyport Set; CIA register writes are not input.
 // ---------------------------------------------------------------------------
-const JOYSTICK_PORT_ADDRESS: Record<1 | 2, number> = {
-  1: 0xDC01,
-  2: 0xDC00,
-};
 
 const JOYSTICK_BIT: Record<string, number> = {
   up: 0,
@@ -223,11 +219,11 @@ export const keyArgsSchema = objectSchema({
 });
 
 export const joystickArgsSchema = objectSchema({
-  description: "Simulate joystick input. On C64U/U64 this uses machine:input (a C64U firmware version that provides it, or U64 3.15+); VICE writes CIA1 registers.",
+  description: "Simulate joystick input. On C64U/U64 this uses machine:input; VICE uses Binary Monitor Joyport Set.",
   properties: {
     op: literalSchema("joystick"),
     port: numberSchema({
-      description: "Joystick port (1 = $DC01, 2 = $DC00).",
+    description: "Joystick port (1 or 2).",
       integer: true,
       minimum: 1,
       maximum: 2,
@@ -370,19 +366,18 @@ const inputOperationHandlers: OperationHandlerMap<InputOperationMap> = {
         });
       }
 
-      const addr = JOYSTICK_PORT_ADDRESS[port];
       if (parsed.controls.some((control) => !(control in JOYSTICK_BIT))) {
         throw new ToolValidationError("VICE joystick supports up, down, left, right, and fire only.", { path: "$.controls" });
       }
 
       if (parsed.action === "release") {
-        await ctx.client.viceMemSet(addr, Uint8Array.of(releasedByte));
-        ctx.logger.info("Released joystick", { port, address: `$${addr.toString(16).toUpperCase()}` });
+        await ctx.client.viceJoyportSet(port, releasedByte);
+        ctx.logger.info("Released joystick", { port });
         return textResult(`Joystick port ${port} released.`, { success: true, port, action: "release" });
       }
 
       if (parsed.action === "press") {
-        await ctx.client.viceMemSet(addr, Uint8Array.of(pressedByte));
+        await ctx.client.viceJoyportSet(port, pressedByte);
         ctx.logger.info("Pressed joystick", { port, controls: parsed.controls, byte: pressedByte });
         return textResult(
           `Joystick port ${port} pressed: ${parsed.controls.join(", ") || "none"}.`,
@@ -391,9 +386,9 @@ const inputOperationHandlers: OperationHandlerMap<InputOperationMap> = {
       }
 
       // tap: press → wait → release
-      await ctx.client.viceMemSet(addr, Uint8Array.of(pressedByte));
+      await ctx.client.viceJoyportSet(port, pressedByte);
       await new Promise<void>((res) => setTimeout(res, durationMs));
-      await ctx.client.viceMemSet(addr, Uint8Array.of(releasedByte));
+      await ctx.client.viceJoyportSet(port, releasedByte);
       ctx.logger.info("Tapped joystick", { port, controls: parsed.controls, durationMs });
       return textResult(
         `Joystick port ${port} tapped: ${parsed.controls.join(", ") || "none"} for ${durationMs}ms.`,

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -296,10 +296,7 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
       });
     }
 
-    // Pin the facade for this entire pause/read/write/read/resume sequence.
-    // A concurrent c64_select_backend must not retarget a step already
-    // underway (HARD01-016).
-    const pinnedFacade = ctx.client.pinFacade ? await ctx.client.pinFacade() : undefined;
+    const pinnedFacade = ctx.client.pinFacade ? await ctx.client.pinFacade() : undefined; // Pin for this whole pause/read/write/resume sequence so a concurrent select_backend can't retarget it (HARD01-016).
     const canPause = supportsMachinePause(ctx);
     let paused = false;
     try {
@@ -411,9 +408,7 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
         verificationMetadata.preReadMismatches = preMismatches;
       }
 
-      // Resume before exposing a verified success. A failed resume leaves the
-      // machine paused, so it is a recoverable operation failure, not a log.
-      if (paused) {
+      if (paused) { // A failed resume here leaves the machine paused: a recoverable operation failure, not a log.
         const resumeResult = await ctx.client.resume(pinnedFacade);
         if (!resumeResult.success) {
           throw new ToolExecutionError("Write completed but the machine could not be resumed", {
@@ -427,7 +422,6 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
         }
         paused = false;
       }
-
       return textResult(`Wrote ${resolvedLength ?? "the provided"} bytes starting at ${resolvedAddress} (verified).`, {
         success: true,
         address: resolvedAddress,

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -296,11 +296,15 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
       });
     }
 
+    // Pin the facade for this entire pause/read/write/read/resume sequence.
+    // A concurrent c64_select_backend must not retarget a step already
+    // underway (HARD01-016).
+    const pinnedFacade = ctx.client.pinFacade ? await ctx.client.pinFacade() : undefined;
     const canPause = supportsMachinePause(ctx);
     let paused = false;
     try {
       if (canPause) {
-        const pauseResult = await ctx.client.pause();
+        const pauseResult = await ctx.client.pause(pinnedFacade);
         if (!pauseResult.success) {
           throw new ToolExecutionError("C64 firmware reported failure while pausing", {
             details: normaliseFailure(pauseResult.details),
@@ -313,7 +317,7 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
       const maskBytes = maskInfo?.bytes;
       const readLength = Math.max(1, Math.max(writeInfo.bytes.length, expectedBytes.length));
 
-      const preRead = await ctx.client.readMemory(parsed.address, String(readLength));
+      const preRead = await ctx.client.readMemory(parsed.address, String(readLength), pinnedFacade);
       if (!preRead.success) {
         throw new ToolExecutionError("C64 firmware reported failure while reading memory", {
           details: normaliseFailure(preRead.details),
@@ -346,14 +350,14 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
         }
       }
 
-      const writeResult = await ctx.client.writeMemory(parsed.address, writeInfo.canonical);
+      const writeResult = await ctx.client.writeMemory(parsed.address, writeInfo.canonical, pinnedFacade);
       if (!writeResult.success) {
         throw new ToolExecutionError("C64 firmware reported failure while writing memory", {
           details: normaliseFailure(writeResult.details),
         });
       }
 
-      const postRead = await ctx.client.readMemory(parsed.address, String(Math.max(1, writeInfo.bytes.length)));
+      const postRead = await ctx.client.readMemory(parsed.address, String(Math.max(1, writeInfo.bytes.length)), pinnedFacade);
       if (!postRead.success) {
         throw new ToolExecutionError("C64 firmware reported failure while reading back memory", {
           details: normaliseFailure(postRead.details),
@@ -407,6 +411,23 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
         verificationMetadata.preReadMismatches = preMismatches;
       }
 
+      // Resume before exposing a verified success. A failed resume leaves the
+      // machine paused, so it is a recoverable operation failure, not a log.
+      if (paused) {
+        const resumeResult = await ctx.client.resume(pinnedFacade);
+        if (!resumeResult.success) {
+          throw new ToolExecutionError("Write completed but the machine could not be resumed", {
+            details: {
+              machinePaused: true,
+              resume: normaliseFailure(resumeResult.details),
+              recovery: "Call c64_system with op 'resume' before further machine operations.",
+              verification: verificationMetadata,
+            },
+          });
+        }
+        paused = false;
+      }
+
       return textResult(`Wrote ${resolvedLength ?? "the provided"} bytes starting at ${resolvedAddress} (verified).`, {
         success: true,
         address: resolvedAddress,
@@ -420,7 +441,7 @@ async function executeWriteMemory(rawArgs: unknown, ctx: ToolExecutionContext): 
     } finally {
       if (paused) {
         try {
-          const resumeResult = await ctx.client.resume();
+          const resumeResult = await ctx.client.resume(pinnedFacade);
           if (!resumeResult.success) {
             ctx.logger.warn("C64 resume reported failure after write", {
               details: normaliseFailure(resumeResult.details),

--- a/src/tools/meta/artifacts.ts
+++ b/src/tools/meta/artifacts.ts
@@ -2,9 +2,9 @@
 import type { ToolDefinition } from "../types.js";
 import { objectSchema, stringSchema, arraySchema, numberSchema, optionalSchema, booleanSchema } from "../schema.js";
 import { jsonResult } from "../responses.js";
-import { ToolError, toolErrorResult, unknownErrorResult } from "../errors.js";
+import { ToolError, ToolValidationError, toolErrorResult, unknownErrorResult } from "../errors.js";
 import { promises as fs } from "node:fs";
-import { resolve as resolvePath, join as joinPath } from "node:path";
+import { resolve as resolvePath, join as joinPath, relative, sep, isAbsolute } from "node:path";
 
 const bundleRunArtifactsArgsSchema = objectSchema({
   description: "Gather screen capture, memory snapshot, and debugreg into a structured bundle.",
@@ -45,13 +45,16 @@ export const tools: ToolDefinition[] = [
       try {
         const parsed = bundleRunArtifactsArgsSchema.parse(args ?? {});
         const runId = parsed.runId as string;
+        if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(runId) || runId === "." || runId === "..") {
+          throw new ToolValidationError("runId must be a non-empty safe filename (letters, digits, dot, underscore, and dash only).", { path: "$.runId" });
+        }
         const outputPath = resolvePath(String(parsed.outputPath));
         const captureScreen = parsed.captureScreen !== false;
         const captureDebugReg = parsed.captureDebugReg !== false;
         const memoryRanges = (parsed.memoryRanges ?? []) as Array<{ address: string; length: number }>;
 
         await fs.mkdir(outputPath, { recursive: true });
-        const runPath = resolvePath(joinPath(outputPath, runId));
+        const runPath = containedPath(outputPath, runId);
         await fs.mkdir(runPath, { recursive: true });
 
         const artifacts: Record<string, string> = {};
@@ -59,19 +62,19 @@ export const tools: ToolDefinition[] = [
         // Capture screen
         if (captureScreen) {
           const screen = await (ctx.client as any).readScreen();
-          const screenPath = resolvePath(joinPath(runPath, "screen.txt"));
+          const screenPath = containedPath(runPath, "screen.txt");
           await fs.writeFile(screenPath, screen, "utf8");
           artifacts.screen = screenPath;
         }
 
         // Capture memory ranges
         if (memoryRanges.length > 0) {
-          const memoryPath = resolvePath(joinPath(runPath, "memory"));
+          const memoryPath = containedPath(runPath, "memory");
           await fs.mkdir(memoryPath, { recursive: true });
           for (let i = 0; i < memoryRanges.length; i++) {
             const range = memoryRanges[i]!;
             const result = await (ctx.client as any).readMemory(range.address, String(range.length));
-            const rangePath = resolvePath(joinPath(memoryPath, `range_${i}_${range.address}.hex`));
+            const rangePath = containedPath(memoryPath, `range_${i}.hex`);
             await fs.writeFile(rangePath, result.data ?? "", "utf8");
             artifacts[`memory_range_${i}`] = rangePath;
           }
@@ -80,13 +83,13 @@ export const tools: ToolDefinition[] = [
         // Capture debugreg
         if (captureDebugReg) {
           const debugreg = await (ctx.client as any).debugregRead();
-          const debugPath = resolvePath(joinPath(runPath, "debugreg.json"));
+          const debugPath = containedPath(runPath, "debugreg.json");
           await fs.writeFile(debugPath, JSON.stringify(debugreg, null, 2), "utf8");
           artifacts.debugreg = debugPath;
         }
 
         // Write manifest
-        const manifestPath = resolvePath(joinPath(runPath, "manifest.json"));
+        const manifestPath = containedPath(runPath, "manifest.json");
         const manifest = {
           runId,
           createdAt: new Date().toISOString(),
@@ -102,3 +105,11 @@ export const tools: ToolDefinition[] = [
     },
   },
 ];
+
+function containedPath(base: string, name: string): string {
+  if (!name || isAbsolute(name) || name.includes("/") || name.includes("\\")) throw new ToolValidationError("Unsafe artifact filename.");
+  const candidate = resolvePath(joinPath(base, name));
+  const rel = relative(base, candidate);
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) throw new ToolValidationError("Artifact path escapes its output directory.");
+  return candidate;
+}

--- a/src/tools/meta/background.ts
+++ b/src/tools/meta/background.ts
@@ -134,6 +134,13 @@ async function ensureTasksLoaded(): Promise<void> {
     if (parsed && Array.isArray(parsed.tasks)) {
       for (const pt of parsed.tasks as PersistedTask[]) {
         const t = fromPersistedTask(pt);
+        if (t.status === "running") {
+          t.status = "stopped";
+          t.stoppedAt = new Date();
+          t.updatedAt = new Date();
+          t.lastError = "Interrupted by MCP server restart; start the task again to resume monitoring.";
+          t.nextRunAt = null;
+        }
         TASKS.set(t.name, t);
       }
     }
@@ -232,7 +239,10 @@ function scheduleNextRun(task: BackgroundTask, ctx: Parameters<ToolDefinition["e
   task._timer = setTimeout(async () => {
     if (task.status !== "running") return;
     try {
-      await runOperation(task.operation, task.args, ctx);
+      const result = await runOperation(task.operation, task.args, ctx);
+      if (result && typeof result === "object" && "success" in result && (result as { success?: unknown }).success === false) {
+        throw new Error(`Operation returned failure: ${JSON.stringify((result as { details?: unknown }).details ?? result)}`);
+      }
       task.iterations += 1;
       task.updatedAt = new Date();
       if (task.maxIterations && task.iterations >= task.maxIterations) {

--- a/src/tools/pollValidator.ts
+++ b/src/tools/pollValidator.ts
@@ -176,20 +176,20 @@ async function pollBasicOutcome(
         };
       }
       
-      // If we detected RUN and no error yet, continue polling
-      if (runDetected) {
-        // Continue polling for a bit to catch any delayed errors
-        // but if we've been polling for a while without errors, consider it successful
-      }
     } catch (error) {
       logger.debug("Failed to read screen during BASIC polling", { error, pollCount });
     }
-    
     await delay(config.intervalMs);
   }
-  
+  if (!runDetected) { // Neither "RUN" nor an error ever appeared for the whole window. On working backends the firmware's own LOAD/RUN echo shows this text, so its total absence means execution never started despite the reported success (HARD01-011/036).
+    logger.debug("BASIC polling completed without ever observing RUN or an error", { pollCount, elapsed: Date.now() - startTime });
+    return {
+      status: "error",
+      type: "BASIC",
+      message: "No execution activity detected: the firmware reported success, but the program does not appear to have run.",
+    };
+  }
   logger.debug("BASIC polling completed without errors", { pollCount, elapsed: Date.now() - startTime });
-  
   return {
     status: "ok",
     type: "BASIC",
@@ -241,15 +241,9 @@ async function pollAsmOutcome(
     await delay(config.intervalMs);
   }
   
-  // If RUN never appeared, assume instant execution (success)
-  if (!runDetected) {
-    logger.debug("RUN never detected, assuming instant execution");
-    return {
-      status: "ok",
-      type: "ASM",
-    };
+  if (!runDetected) { // Fall through to the liveness check rather than assuming success. Skipping it here used to report false success for any run that never types anything visible, e.g. a firmware run_prg that silently no-ops instead of running the PRG (HARD01-036).
+    logger.debug("RUN never detected; falling through to hardware liveness check instead of assuming success");
   }
-  
   let previousSignature: number | null = null; // Only stable RAM: reading I/O can ack CIA interrupts on Ultimate, and raster/timer values aren't evidence of liveness.
   let alive = false;
   

--- a/src/tools/pollValidator.ts
+++ b/src/tools/pollValidator.ts
@@ -119,9 +119,7 @@ function concatBuffers(...buffers: Uint8Array[]): Uint8Array {
  * Looks for patterns like "?SYNTAX ERROR" or "SYNTAX ERROR IN 120".
  */
 function extractBasicError(screen: string): { message?: string; line?: number } | null {
-  // A BASIC runtime error is printed with a leading question mark. Ordinary
-  // program output such as "0 ERRORS FOUND" must never be treated as one.
-  const errorMatch = /(?:^|\n)\s*\?([A-Z\s]+?)\s+ERROR(?:\s+IN\s+(\d+))?(?=\s|$)/im.exec(screen);
+  const errorMatch = /(?:^|\n)\s*\?([A-Z\s]+?)\s+ERROR(?:\s+IN\s+(\d+))?(?=\s|$)/im.exec(screen); // A real error has a leading "?"; ordinary output like "0 ERRORS FOUND" must never match.
   
   if (errorMatch) {
     const errorType = errorMatch[1]?.trim().replace(/\s+/g, " ");
@@ -252,10 +250,7 @@ async function pollAsmOutcome(
     };
   }
   
-  // Only inspect side-effect-free stable RAM. Reading I/O on Ultimate can
-  // acknowledge CIA interrupts, and raster/timer values are not evidence the
-  // uploaded program is alive.
-  let previousSignature: number | null = null;
+  let previousSignature: number | null = null; // Only stable RAM: reading I/O can ack CIA interrupts on Ultimate, and raster/timer values aren't evidence of liveness.
   let alive = false;
   
   const pollDeadline = Date.now() + config.maxMs;

--- a/src/tools/pollValidator.ts
+++ b/src/tools/pollValidator.ts
@@ -119,15 +119,9 @@ function concatBuffers(...buffers: Uint8Array[]): Uint8Array {
  * Looks for patterns like "?SYNTAX ERROR" or "SYNTAX ERROR IN 120".
  */
 function extractBasicError(screen: string): { message?: string; line?: number } | null {
-  const upperScreen = screen.toUpperCase();
-  
-  // Check if ERROR appears on screen
-  if (!upperScreen.includes("ERROR")) {
-    return null;
-  }
-  
-  // Try to match "?ERROR_TYPE ERROR" or "ERROR_TYPE ERROR IN LINE"
-  const errorMatch = /\?([A-Z\s]+)\s+ERROR(?:\s+IN\s+(\d+))?/i.exec(screen);
+  // A BASIC runtime error is printed with a leading question mark. Ordinary
+  // program output such as "0 ERRORS FOUND" must never be treated as one.
+  const errorMatch = /(?:^|\n)\s*\?([A-Z\s]+?)\s+ERROR(?:\s+IN\s+(\d+))?(?=\s|$)/im.exec(screen);
   
   if (errorMatch) {
     const errorType = errorMatch[1]?.trim().replace(/\s+/g, " ");
@@ -140,8 +134,7 @@ function extractBasicError(screen: string): { message?: string; line?: number } 
     };
   }
   
-  // Fallback: just "ERROR" appears
-  return { message: "UNKNOWN ERROR" };
+  return null;
 }
 
 /**
@@ -259,9 +252,10 @@ async function pollAsmOutcome(
     };
   }
   
-  // Now poll hardware regions to detect activity
-  let prevIoSignature: number | null = null;
-  let prevJiffyClock: Uint8Array | null = null;
+  // Only inspect side-effect-free stable RAM. Reading I/O on Ultimate can
+  // acknowledge CIA interrupts, and raster/timer values are not evidence the
+  // uploaded program is alive.
+  let previousSignature: number | null = null;
   let alive = false;
   
   const pollDeadline = Date.now() + config.maxMs;
@@ -270,26 +264,12 @@ async function pollAsmOutcome(
     pollCount++;
     
     try {
-      // Read I/O regions in optimized batches as per comment #3466803675
-      // All of $D000-$DFFF in a single call (covers VIC-II, SID, CIA1, CIA2)
-      const ioRegions = await client.readMemoryRaw(0xD000, 0x1000); // $D000-$DFFF
-      
-      // Read low memory through screen RAM in a single call: $0000-$07E7
-      // This covers zero page, stack, jiffy clock ($00A0-$00A2), and screen memory
-      const lowMemAndScreen = await client.readMemoryRaw(0x0000, 0x7E8); // $0000-$07E7
-      
-      // Extract jiffy clock for separate comparison (at offset $00A0 in the buffer)
-      const jiffyClock = lowMemAndScreen.slice(0xA0, 0xA3);
-      
-      // Exclude the jiffy clock from the broad signature so it can be tracked separately.
-      const lowMemSignatureBuffer = lowMemAndScreen.slice();
-      lowMemSignatureBuffer.fill(0, 0xA0, 0xA3);
-      const combinedBuffer = concatBuffers(ioRegions, lowMemSignatureBuffer);
-      const ioSignature = computeCrc32(combinedBuffer);
+      const screenRam = await client.readMemoryRaw(0x0400, 0x03e8);
+      const signature = computeCrc32(screenRam);
       
       // Check for any activity
-      if (prevIoSignature !== null && ioSignature !== prevIoSignature) {
-        logger.debug("Hardware or screen activity detected", { 
+      if (previousSignature !== null && signature !== previousSignature) {
+        logger.debug("Program-visible screen activity detected", {
           pollCount, 
           elapsed: Date.now() - startTime,
           signatureChanged: true
@@ -298,18 +278,7 @@ async function pollAsmOutcome(
         break;
       }
       
-      if (prevJiffyClock !== null && !buffersEqual(jiffyClock, prevJiffyClock)) {
-        logger.debug("Jiffy clock advanced", { 
-          pollCount, 
-          elapsed: Date.now() - startTime,
-          clockChanged: true
-        });
-        alive = true;
-        break;
-      }
-      
-      prevIoSignature = ioSignature;
-      prevJiffyClock = jiffyClock;
+      previousSignature = signature;
       
     } catch (error) {
       logger.debug("Failed to read memory during ASM polling", { error, pollCount });
@@ -331,7 +300,7 @@ async function pollAsmOutcome(
   return {
     status: "crashed",
     type: "ASM",
-    reason: "no VIC/CIA/TI/screen progression within window",
+    reason: "no program-visible screen progression within window",
   };
 }
 

--- a/src/tools/printer.ts
+++ b/src/tools/printer.ts
@@ -294,6 +294,7 @@ function validateEpsonDensity(args: EpsonBitmapArgs): void {
 
 export const printerModule = defineToolModule({
   domain: "printer",
+  supportedPlatforms: ["c64u", "u2"],
   summary: "Printer workflow helpers for Commodore MPS and Epson FX devices, including prompt templates.",
   resources: [
     "c64://printer/spec",

--- a/src/tools/registry/platform.ts
+++ b/src/tools/registry/platform.ts
@@ -95,10 +95,7 @@ const platformOperationHandlers: OperationHandlerMap<PlatformOperations> = {
       };
     }
 
-    // A generated arpeggio is pinned to the facade it started on, but a
-    // switch is still the documented cue to stop it rather than let it keep
-    // playing to a backend the caller no longer intends to drive.
-    cancelGeneratedSidPlayback();
+    cancelGeneratedSidPlayback(); // A backend switch is the documented cue to stop it rather than let it keep playing on the old backend.
     ctx.client.switchBackend(backend);
     ctx.setPlatform(backend);
 

--- a/src/tools/registry/platform.ts
+++ b/src/tools/registry/platform.ts
@@ -1,4 +1,5 @@
 import { describePlatformCapabilities, type PlatformId } from "../../platform.js";
+import { cancelGeneratedSidPlayback } from "../audio.js";
 import { debugModuleGroup as debugModule } from "../debug.js";
 import { viceModuleGroup as viceModule } from "../vice.js";
 import { jsonResult } from "../responses.js";
@@ -94,6 +95,10 @@ const platformOperationHandlers: OperationHandlerMap<PlatformOperations> = {
       };
     }
 
+    // A generated arpeggio is pinned to the facade it started on, but a
+    // switch is still the documented cue to stop it rather than let it keep
+    // playing to a backend the caller no longer intends to drive.
+    cancelGeneratedSidPlayback();
     ctx.client.switchBackend(backend);
     ctx.setPlatform(backend);
 

--- a/src/tools/registry/printer.ts
+++ b/src/tools/registry/printer.ts
@@ -169,6 +169,7 @@ function invokePrintTool(toolName: string, rawArgs: Record<string, unknown>, ctx
 
 export const printerModuleGroup = defineToolModule({
   domain: "printer",
+  supportedPlatforms: ["c64u", "u2"],
   summary: "Grouped printer text, bitmap, and character definition helpers.",
   resources: ["c64://guide/bootstrap"],
   defaultTags: ["printer", "device"],

--- a/src/tools/translation/assembler.ts
+++ b/src/tools/translation/assembler.ts
@@ -13,7 +13,9 @@ import type { OpcodeAddressingMode } from "./opcodeInventory.js";
 export interface AssembleOptions {
   /**
    * Optional default load address used when no ORG or `* =` directive appears.
-   * Defaults to $0801 so that the output PRG can be run with SYS 2061.
+   * Defaults to $0801 (the conventional BASIC-adjacent origin for standalone
+   * machine code). The PRG's first two bytes double as its entry point;
+   * callers run it via a typed `SYS <entry>`, not `RUN`.
    */
   loadAddress?: number;
   /**

--- a/src/vice/mockServer.ts
+++ b/src/vice/mockServer.ts
@@ -235,6 +235,14 @@ export class ViceMockServer {
         if (start <= SCREEN_BASE && end >= SCREEN_BASE) {
           this.helloReady = false;
         }
+        // This mock does not run real 6502 code, so nothing else drains the
+        // KERNAL keyboard buffer's pending-count byte ($00C6/NDX). Simulate
+        // the KERNAL IRQ consuming it shortly after each write, mirroring
+        // real VICE/hardware behaviour closely enough for deterministic tests.
+        const KEYBOARD_NDX = 0x00c6;
+        if (start <= KEYBOARD_NDX && end >= KEYBOARD_NDX) {
+          setTimeout(() => { this.memory[KEYBOARD_NDX] = 0; }, 5);
+        }
         return buildResponse(cmd, reqId);
       }
       case 0x72: { // keyboard feed

--- a/src/vice/mockServer.ts
+++ b/src/vice/mockServer.ts
@@ -235,13 +235,9 @@ export class ViceMockServer {
         if (start <= SCREEN_BASE && end >= SCREEN_BASE) {
           this.helloReady = false;
         }
-        // This mock does not run real 6502 code, so nothing else drains the
-        // KERNAL keyboard buffer's pending-count byte ($00C6/NDX). Simulate
-        // the KERNAL IRQ consuming it shortly after each write, mirroring
-        // real VICE/hardware behaviour closely enough for deterministic tests.
-        const KEYBOARD_NDX = 0x00c6;
+        const KEYBOARD_NDX = 0x00c6; // This mock runs no real 6502 code, so simulate the KERNAL IRQ draining $00C6 shortly after each write.
         if (start <= KEYBOARD_NDX && end >= KEYBOARD_NDX) {
-          setTimeout(() => { this.memory[KEYBOARD_NDX] = 0; }, 5);
+          setTimeout(() => { this.memory[KEYBOARD_NDX] = 0; }, 5).unref();
         }
         return buildResponse(cmd, reqId);
       }

--- a/src/vice/mockServer.ts
+++ b/src/vice/mockServer.ts
@@ -3,6 +3,10 @@ import { asciiToScreenCodes } from "./readiness.js";
 
 const SCREEN_BASE = 0x0400;
 const SCREEN_SIZE = 40 * 25;
+const KEYBOARD_BUFFER = 0x0277; // KERNAL keyboard buffer base ($0277), where a typed SYS command lands.
+const SYS_COMMAND_PATTERN = /SYS\s*\d+/i; // upload_run_asm enters an assembled program via a typed SYSnnnnn.
+const HEARTBEAT_GRANULARITY_MS = 10; // Well below the poll interval so consecutive liveness reads always differ.
+const HEARTBEAT_DURATION_MS = 1000; // How long a SYS-triggered program keeps "running".
 
 interface MockCheckpoint {
   id: number;
@@ -62,6 +66,7 @@ export class ViceMockServer {
   private server: net.Server | null = null;
   private memory = new Uint8Array(0x10000);
   private helloReady = false;
+  private heartbeat: { startedAt: number; baseValue: number } | null = null;
   private checkpoints = new Map<number, MockCheckpoint>();
   private nextCheckpointId = 1;
   private readonly registerMetadata = buildDefaultRegisterMetadata();
@@ -223,6 +228,7 @@ export class ViceMockServer {
         for (let i = 0; i < length; i += 1) {
           payload[2 + i] = this.memory[(start + i) & 0xffff];
         }
+        this.applyHeartbeatOverlay(start, length, payload);
         return buildResponse(cmd, reqId, payload);
       }
       case 0x02: { // mem set
@@ -234,7 +240,9 @@ export class ViceMockServer {
         }
         if (start <= SCREEN_BASE && end >= SCREEN_BASE) {
           this.helloReady = false;
+          this.heartbeat = null; // A client writing screen RAM has taken over; end any simulated run.
         }
+        this.maybeStartAsmHeartbeat(start, end, payload);
         const KEYBOARD_NDX = 0x00c6; // This mock runs no real 6502 code, so simulate the KERNAL IRQ draining $00C6 shortly after each write.
         if (start <= KEYBOARD_NDX && end >= KEYBOARD_NDX) {
           setTimeout(() => { this.memory[KEYBOARD_NDX] = 0; }, 5).unref();
@@ -451,6 +459,7 @@ export class ViceMockServer {
     this.memory[0x2F] = 0x03; this.memory[0x30] = 0x08;
     this.memory[0x31] = 0x03; this.memory[0x32] = 0x08;
     this.helloReady = false;
+    this.heartbeat = null;
     this.checkpoints.clear();
     this.nextCheckpointId = 1;
     this.registerValues.clear();
@@ -470,6 +479,23 @@ export class ViceMockServer {
     const hello = asciiToScreenCodes("HELLO");
     hello.copy(Buffer.from(this.memory.buffer, offset, hello.length));
     this.helloReady = true;
+  }
+
+  private maybeStartAsmHeartbeat(start: number, end: number, payload: Buffer): void { // upload_run_asm enters via a typed SYS in the keyboard buffer; this mock runs no 6502 code, so record a time-computed "alive" window (a descriptor, never a background timer, so nothing leaks into a shared-server test).
+    if (start > KEYBOARD_BUFFER || end < KEYBOARD_BUFFER) return; // Only a write covering the KERNAL keyboard buffer can be a typed SYS trigger.
+    if (!SYS_COMMAND_PATTERN.test(payload.toString("ascii"))) return;
+    this.heartbeat = { startedAt: Date.now(), baseValue: this.memory[SCREEN_BASE]! };
+  }
+
+  private applyHeartbeatOverlay(start: number, length: number, payload: Buffer): void { // Overlay a synthetic, time-advancing byte at the screen base while a SYS "alive" window is open: a pure function of elapsed time applied only to the response, so stored memory never mutates on its own.
+    const heartbeat = this.heartbeat;
+    if (!heartbeat) return;
+    const elapsed = Date.now() - heartbeat.startedAt;
+    if (elapsed < 0 || elapsed >= HEARTBEAT_DURATION_MS) return;
+    const offset = SCREEN_BASE - start;
+    if (offset < 0 || offset >= length) return;
+    const ticks = Math.floor(elapsed / HEARTBEAT_GRANULARITY_MS);
+    payload[2 + offset] = (heartbeat.baseValue + ticks) & 0xff;
   }
 }
 

--- a/src/vice/process.ts
+++ b/src/vice/process.ts
@@ -21,6 +21,7 @@ export interface ViceProcessHandle {
   readonly port: number;
   readonly process: ChildProcess;
   stop(): Promise<void>;
+  stopSync(): void;
 }
 
 const DEFAULT_DISPLAY = ":99";
@@ -404,11 +405,21 @@ export async function startViceProcess(options: ViceProcessOptions): Promise<Vic
     }
   };
 
+  const stopSync = (): void => {
+    for (const process of [child, xvfb]) {
+      if (!process || process.exitCode !== null || process.signalCode !== null) continue;
+      try { process.kill("SIGTERM"); } catch {}
+      if (process.exitCode === null && process.signalCode === null) {
+        try { process.kill("SIGKILL"); } catch {}
+      }
+    }
+  };
+
   child.once("exit", async () => {
     await terminateProcess(xvfb, "SIGTERM", 0);
   });
 
-  return { host: options.host, port: options.port, process: child, stop };
+  return { host: options.host, port: options.port, process: child, stop, stopSync };
 }
 
 function isIgnorableSocketDirError(error: unknown): boolean {

--- a/src/vice/process.ts
+++ b/src/vice/process.ts
@@ -405,13 +405,10 @@ export async function startViceProcess(options: ViceProcessOptions): Promise<Vic
     }
   };
 
-  const stopSync = (): void => {
+  const stopSync = (): void => { // Runs from signal handlers: no later tick to observe SIGTERM, so go straight to SIGKILL.
     for (const process of [child, xvfb]) {
       if (!process || process.exitCode !== null || process.signalCode !== null) continue;
-      try { process.kill("SIGTERM"); } catch {}
-      if (process.exitCode === null && process.signalCode === null) {
-        try { process.kill("SIGKILL"); } catch {}
-      }
+      try { process.kill("SIGKILL"); } catch {}
     }
   };
 

--- a/src/vice/viceClient.ts
+++ b/src/vice/viceClient.ts
@@ -79,11 +79,13 @@ interface PendingRequest {
   resolve: (frame: Buffer) => void;
   reject: (err: unknown) => void;
   onFrame?: (type: number, frame: Buffer) => void;
+  timer?: NodeJS.Timeout;
 }
 
 interface SendOptions {
   readonly responseType?: number;
   readonly onFrame?: (type: number, frame: Buffer) => void;
+  readonly timeoutMs?: number;
 }
 
 export class ViceClient {
@@ -140,6 +142,7 @@ export class ViceClient {
 
   private rejectAllPending(reason: unknown): void {
     for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
       try {
         pending.reject(reason);
       } catch {}
@@ -153,7 +156,7 @@ export class ViceClient {
     // Frame: [0]=0x02, [1]=0x02, [2..5]=len, [6]=respType, [7]=err, [8..11]=reqId, [12..]=body
     while (this.buffer.length >= 12) {
       if (this.buffer[0] !== 0x02 || this.buffer[1] !== 0x02) {
-        const idx = this.buffer.indexOf(0x02, 1);
+        const idx = this.buffer.indexOf(Buffer.from([0x02, 0x02]), 1);
         this.buffer = idx === -1 ? Buffer.alloc(0) : this.buffer.subarray(idx);
         continue;
       }
@@ -179,6 +182,7 @@ export class ViceClient {
       }
 
       if (err !== 0x00) {
+        if (pending.timer) clearTimeout(pending.timer);
         pending.reject(new Error(`BM error 0x${err.toString(16)}`));
         this.pending.delete(reqId);
         continue;
@@ -189,6 +193,7 @@ export class ViceClient {
           try {
             pending.onFrame(responseType, frame);
           } catch (error) {
+            if (pending.timer) clearTimeout(pending.timer);
             pending.reject(error);
             this.pending.delete(reqId);
           }
@@ -201,6 +206,7 @@ export class ViceClient {
       }
 
       pending.resolve(frame);
+      if (pending.timer) clearTimeout(pending.timer);
       this.pending.delete(reqId);
     }
   }
@@ -209,7 +215,7 @@ export class ViceClient {
     if (!this.socket || this.socket.destroyed) {
       return Promise.reject(new Error("VICE monitor socket is not connected"));
     }
-    const reqId = this.nextReqId++;
+    const reqId = this.nextReqId++ >>> 0;
     const payload = body ?? Buffer.alloc(0);
     const header = Buffer.alloc(11);
     header[0] = 0x02; // STX
@@ -221,12 +227,19 @@ export class ViceClient {
     const expectedCmd = options?.responseType ?? cmd;
 
     const promise = new Promise<Buffer>((resolve, reject) => {
-      this.pending.set(reqId, {
+      const pending: PendingRequest = {
         cmd: expectedCmd,
         resolve,
         reject,
         onFrame: options?.onFrame,
-      });
+      };
+      const timeoutMs = options?.timeoutMs ?? (cmd === 0x84 ? 30_000 : 10_000);
+      pending.timer = setTimeout(() => {
+        if (!this.pending.delete(reqId)) return;
+        reject(new Error(`VICE monitor request 0x${cmd.toString(16)} timed out after ${timeoutMs}ms`));
+        this.socket?.destroy();
+      }, timeoutMs);
+      this.pending.set(reqId, pending);
     });
 
     this.socket.write(packet);
@@ -277,6 +290,14 @@ export class ViceClient {
     await this.send(0x72, body);
   }
 
+  /** Set the VICE joyport's active-low control byte (BM command 0xA2). */
+  async joyportSet(port: 1 | 2, activeLowMask: number): Promise<void> {
+    const body = Buffer.alloc(4);
+    body.writeUInt16LE(port, 0);
+    body.writeUInt16LE(activeLowMask & 0xff, 2);
+    await this.send(0xA2, body);
+  }
+
   async checkpointGet(id: number): Promise<ViceCheckpoint> {
     const body = Buffer.alloc(4);
     body.writeUInt32LE(id >>> 0, 0);
@@ -289,8 +310,11 @@ export class ViceClient {
     const end = (options.end ?? options.start) & 0xffff;
     const stop = options.stopOnHit !== false;
     const enabled = options.enabled !== false;
-    const ops = options.operations ?? { execute: true };
-    const mask = (ops.load ? 0x01 : 0) | (ops.store ? 0x02 : 0) | (ops.execute === false ? 0 : 0x04);
+    const ops = options.operations;
+    const hasExplicitOperation = ops && (ops.load !== undefined || ops.store !== undefined || ops.execute !== undefined);
+    const mask = hasExplicitOperation
+      ? ((ops?.load ? 0x01 : 0) | (ops?.store ? 0x02 : 0) | (ops?.execute ? 0x04 : 0))
+      : 0x04;
     const temporary = options.temporary === true;
     const memspace = options.memspace ?? 0;
     const hasMemspace = options.memspace !== undefined;

--- a/src/vice/viceClient.ts
+++ b/src/vice/viceClient.ts
@@ -215,6 +215,9 @@ export class ViceClient {
     if (!this.socket || this.socket.destroyed) {
       return Promise.reject(new Error("VICE monitor socket is not connected"));
     }
+    if (this.nextReqId === 0xffffffff) { // Reserved for unsolicited events (see onData above); skip it on wraparound.
+      this.nextReqId = 0;
+    }
     const reqId = this.nextReqId++ >>> 0;
     const payload = body ?? Buffer.alloc(0);
     const header = Buffer.alloc(11);

--- a/test/audioModule.test.mjs
+++ b/test/audioModule.test.mjs
@@ -82,11 +82,13 @@ test("music_generate builds timeline and triggers SID sequence", async () => {
   assert.equal(result.metadata.steps, 2);
   assert.equal(result.metadata.timeline.length, 2);
 
-  await new Promise((resolve) => setTimeout(resolve, 120));
+  await new Promise((resolve) => setTimeout(resolve, 300));
 
   assert.equal(volumeCalls.length, 1);
   assert.equal(noteCalls.length, 2);
-  assert.equal(noteOffCount, 1);
+  // HARD01-033: the gate is cleared between every note (steps) plus a final
+  // release, so envelope articulation retriggers for each note.
+  assert.equal(noteOffCount, 3);
   assert.deepEqual(noteCalls.map((call) => call.note), ["C4", "E4"]);
 });
 
@@ -123,7 +125,10 @@ test("music_generate defaults to triangle waveform and best-practice ADSR", asyn
   assert.equal(call.decay, 7);
   assert.equal(call.sustain, 15);
   assert.equal(call.release, 0);
-  assert.equal(noteOffCount, 1);
+  // HARD01-033: one gate-clear before the (non-existent) next note never
+  // happens for a single-step run, but the trailing release still fires,
+  // plus the loop's own gate-clear for its one note.
+  assert.equal(noteOffCount, 2);
 });
 
 test("music_generate expression preset uses varied durations and reports preset", async () => {
@@ -171,6 +176,50 @@ test("music_generate survives playback error and logs", async () => {
   assert.equal(result.isError, undefined);
   await new Promise((r) => setTimeout(r, 40));
   assert.equal(noteOnCalls, 1);
+});
+
+test("HARD01-030 music_generate pins its facade so a mid-playback backend switch cannot retarget later notes", async () => {
+  const events = [];
+  let activeFacadeType = "vice";
+  const viceFacade = { type: "vice" };
+  const c64uFacade = { type: "c64u" };
+
+  const ctx = {
+    client: {
+      async pinFacade() {
+        return activeFacadeType === "vice" ? viceFacade : c64uFacade;
+      },
+      async sidSetVolume(volume, facade) {
+        events.push({ op: "volume", facade: facade?.type });
+        return { success: true };
+      },
+      async sidNoteOn(payload, facade) {
+        events.push({ op: `note-on-${payload.note}`, facade: facade?.type });
+        // Simulate a concurrent c64_select_backend firing mid-arpeggio.
+        activeFacadeType = "c64u";
+        return { success: true };
+      },
+      async sidNoteOff(voice, facade) {
+        events.push({ op: "note-off", facade: facade?.type });
+        return { success: true };
+      },
+    },
+    logger: createLogger(),
+  };
+
+  const result = await audioModule.invoke(
+    "music_generate",
+    { root: "C4", pattern: "0,4", steps: 2, tempoMs: 20, waveform: "tri" },
+    ctx,
+  );
+  assert.equal(result.isError, undefined);
+
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  // Every write must have used the facade pinned when the arpeggio started
+  // (vice), never the one made active by the mid-flight switch (c64u).
+  assert.ok(events.length > 0);
+  assert.ok(events.every((event) => event.facade === "vice"), JSON.stringify(events));
 });
 
 test("music_compile_and_play compiles SIDWAVE to PRG and runs on C64", async () => {

--- a/test/c64Client.test.mjs
+++ b/test/c64Client.test.mjs
@@ -11,6 +11,7 @@ import {
   buildCommodoreBitmapBasicProgram,
   buildEpsonBitmapBasicProgram,
   buildCommodoreDllBasicProgram,
+  buildPetsciiScreenBasic,
 } from "../src/c64Client.js";
 import { basicToPrg } from "../src/tools/translation/basicTokenizer.js";
 import { startMockC64Server } from "../scripts/mockC64Server.mjs";
@@ -202,9 +203,18 @@ test("C64Client against mock server", async (t) => {
     assert.deepEqual(Array.from(mock.state.lastPrg), Array.from(expectedPrg));
   });
 
-  await t.test("buildPrinterBasicProgram splits long lines and escapes quotes", () => {
+  await t.test("HARD01-007 buildPrinterBasicProgram uses CHR$(34) for quotes", () => {
     const src = buildPrinterBasicProgram({ text: 'A"B' });
-    assert.ok(src.includes('PRINT#1,"A""B"'));
+    assert.ok(src.includes('PRINT#1,"A";CHR$(34);"B"'));
+    assert.equal(src.includes('""B'), false);
+  });
+
+  await t.test("HARD01-008 buildPetsciiScreenBasic actually waits for a key instead of falling through to READY.", () => {
+    const src = buildPetsciiScreenBasic({ text: "HELLO" });
+    // The wait line must branch back to itself while no key is pending, and
+    // only fall through (to END) once a key has actually been pressed.
+    assert.match(src, /30 GETA\$:IFA\$=""THEN30/);
+    assert.equal(/30 GETA\$:IFA\$<>""THEN/.test(src), false, "must not use the old non-blocking condition");
   });
 
   await t.test("Commodore BIM builder sets bit7 and emits DATA lines", () => {
@@ -372,11 +382,23 @@ test("C64Client against mock server", async (t) => {
     assert.equal(mock.state.lastWrite.bytes[0], 0x00);
   });
 
+  await t.test("HARD01-032 A4 (440Hz) on PAL resolves to the literal SID register value $1D45 (7493), not the old 2^16 formula", async () => {
+    const client = new C64Client(mock.baseUrl);
+    await client.sidNoteOn({ voice: 1, note: "A4", waveform: "tri", attack: 1, decay: 7, sustain: 15, release: 0, system: "PAL" });
+    assert.equal(mock.state.lastWrite.address, 0xd400);
+    const lo = mock.state.lastWrite.bytes[0];
+    const hi = mock.state.lastWrite.bytes[1];
+    // 24-bit phase accumulator: round(440 * 2^24 / 985248) = 7493 = $1D45.
+    assert.equal(lo, 0x45);
+    assert.equal(hi, 0x1d);
+    assert.equal((hi << 8) | lo, 7493);
+  });
+
   await t.test("SID frequency bytes are correct for PAL vs NTSC", async () => {
     const client = new C64Client(mock.baseUrl);
     function expectFreqBytes(hz, system) {
       const phi2 = system === "PAL" ? 985_248 : 1_022_727;
-      const value = Math.round((hz * 65536) / phi2) & 0xffff;
+      const value = Math.round((hz * 16777216) / phi2) & 0xffff;
       const lo = value & 0xff;
       const hi = (value >> 8) & 0xff;
       return { lo, hi };
@@ -428,6 +450,38 @@ test("C64Client against mock server", async (t) => {
     const result = await client.runPrg(prg);
     assert.equal(result.success, true);
     assert.equal(mock.state.runCount, before + 1);
+  });
+
+  await t.test("HARD01-018 uploadAndRunAsm loads the assembled PRG without running it and enters via a typed SYS to the real entry point", async () => {
+    const before = mock.state.loadCount;
+    // The tool's own published example.
+    const result = await client.uploadAndRunAsm(".org $0801\nstart: lda #$01\n sta $0400\n rts");
+    assert.equal(result.success, true);
+    assert.equal(result.details.entryAddress, 0x0801);
+
+    // Loaded (not LOAD+RUN): the firmware :load_prg endpoint was used, not
+    // :run_prg, and the code landed at its own address in emulated memory.
+    assert.equal(mock.state.loadCount, before + 1);
+    assert.equal(mock.state.memory[0x0801], 0xa9); // LDA #imm opcode
+    assert.equal(mock.state.memory[0x0802], 0x01);
+
+    // Entered via a typed SYS to the real entry point, never a bare RUN.
+    const sysWrite = mock.state.writeLog.slice().reverse().find((entry) => entry.address === 0x0277);
+    assert.ok(sysWrite, "expected a write to the KERNAL keyboard buffer");
+    assert.equal(Buffer.from(sysWrite.bytes).toString("ascii"), "SYS2049\r");
+  });
+
+  await t.test("HARD01-018 uploadAndRunAsm keeps a non-$0801 origin intact instead of corrupting BASIC pointers", async () => {
+    const before = mock.state.loadCount;
+    const result = await client.uploadAndRunAsm(".org $C000\nstart: lda #$07\n sta $D020\n rts");
+    assert.equal(result.success, true);
+    assert.equal(result.details.entryAddress, 0xC000);
+    assert.equal(mock.state.loadCount, before + 1);
+    assert.equal(mock.state.memory[0xC000], 0xa9);
+
+    const sysWrite = mock.state.writeLog.slice().reverse().find((entry) => entry.address === 0x0277);
+    assert.ok(sysWrite, "expected a write to the KERNAL keyboard buffer");
+    assert.equal(Buffer.from(sysWrite.bytes).toString("ascii"), "SYS49152\r");
   });
 
   await t.test("reset returns success", async () => {
@@ -668,8 +722,8 @@ test("C64Client backend selection and switching", async (t) => {
 
     await withConfigScenario(
       {
-        repoConfig: { c64u: { baseUrl: c64u.baseUrl } },
-        homeConfig: { vice: { host: "127.0.0.1", port: vice.port } },
+        repoConfig: { c64u: { baseUrl: c64u.baseUrl }, vice: { host: "127.0.0.1", port: vice.port } },
+        homeConfig: null,
         mode: "vice",
       },
       async () => {
@@ -708,6 +762,48 @@ test("C64Client backend selection and switching", async (t) => {
     );
   });
 
+  await t.test("HARD01-016 a pinned facade keeps write/read on the original backend across a mid-flight switchBackend", async () => {
+    const c64u = await startMockC64Server();
+    const vice = await startViceMockServer({ host: "127.0.0.1", port: 0 });
+    t.after(async () => {
+      await Promise.all([c64u.close(), vice.stop()]);
+    });
+
+    await withConfigScenario(
+      {
+        repoConfig: { c64u: { baseUrl: c64u.baseUrl }, vice: { host: "127.0.0.1", port: vice.port } },
+        homeConfig: null,
+        mode: "vice",
+      },
+      async () => {
+        const client = new C64Client("http://unused.local", { forceC64uFacade: false });
+        assert.equal(await client.getActiveBackendType(), "vice");
+
+        const pinnedFacade = await client.pinFacade();
+
+        // A concurrent select_backend call must not affect steps already
+        // holding a pinned facade snapshot.
+        client.switchBackend("c64u");
+        assert.equal(await client.getActiveBackendType(), "c64u");
+
+        const writeResult = await client.writeMemory("$C000", "$AA", pinnedFacade);
+        assert.equal(writeResult.success, true);
+
+        const readResult = await client.readMemory("$C000", "1", pinnedFacade);
+        assert.equal(readResult.success, true);
+        assert.equal(readResult.data, "$AA");
+
+        // The c64u mock must never have seen any of the pinned operations.
+        assert.ok(!c64u.state.lastRequest);
+
+        // A fresh, unpinned call now correctly targets the switched-to backend.
+        const c64uInfo = await client.info();
+        assert.ok(c64uInfo && typeof c64uInfo === "object");
+        assert.match(c64u.state.lastRequest?.url ?? "", /\/v1\/info$/);
+      },
+    );
+  });
+
   await t.test("vice backend stays lazy until a vice-routed request needs it", async () => {
     const c64u = await startMockC64Server();
     const vice = await startViceMockServer({ host: "127.0.0.1", port: 0 });
@@ -717,8 +813,8 @@ test("C64Client backend selection and switching", async (t) => {
 
     await withConfigScenario(
       {
-        repoConfig: { c64u: { baseUrl: c64u.baseUrl } },
-        homeConfig: { vice: { host: "127.0.0.1", port: vice.port } },
+        repoConfig: { c64u: { baseUrl: c64u.baseUrl }, vice: { host: "127.0.0.1", port: vice.port } },
+        homeConfig: null,
         mode: "c64u",
       },
       async () => {

--- a/test/c64Client.test.mjs
+++ b/test/c64Client.test.mjs
@@ -19,7 +19,6 @@ import { startViceMockServer } from "../src/vice/mockServer.js";
 
 const SCREEN_BASE = "$0400";
 const SAFE_RAM_BASE = "$C000";
-const REPO_CONFIG_PATH = path.resolve(".c64bridge.json");
 
 function asciiToHexBytes(text) {
   return Buffer.from(text, "ascii").toString("hex").toUpperCase();
@@ -63,16 +62,21 @@ async function withConfigScenario({
   const envConfigPath = path.join(tempRoot, "env.json");
   const homeDir = path.join(tempRoot, "home");
   const homeConfigPath = path.join(homeDir, ".c64bridge.json");
-  const hadRepoConfig = fs.existsSync(REPO_CONFIG_PATH);
-  const originalRepoConfig = hadRepoConfig ? fs.readFileSync(REPO_CONFIG_PATH, "utf8") : null;
+  // Use an isolated cwd rather than the real repo root: loadConfig() resolves
+  // its "cwd config" candidate from process.cwd() fresh on every call, and
+  // several test files exercise this same scenario concurrently (each in its
+  // own process). Writing to the literal repo-root .c64bridge.json would
+  // race across those processes on the same real file.
+  const cwdDir = path.join(tempRoot, "cwd");
+  const cwdConfigPath = path.join(cwdDir, ".c64bridge.json");
+  const previousCwd = process.cwd();
 
   fs.mkdirSync(homeDir, { recursive: true });
+  fs.mkdirSync(cwdDir, { recursive: true });
 
   try {
-    if (repoConfig === null) {
-      fs.rmSync(REPO_CONFIG_PATH, { force: true });
-    } else if (repoConfig !== undefined) {
-      fs.writeFileSync(REPO_CONFIG_PATH, JSON.stringify(repoConfig), "utf8");
+    if (repoConfig !== null && repoConfig !== undefined) {
+      fs.writeFileSync(cwdConfigPath, JSON.stringify(repoConfig), "utf8");
     }
 
     if (homeConfig !== undefined) {
@@ -87,18 +91,15 @@ async function withConfigScenario({
       fs.writeFileSync(envConfigPath, JSON.stringify(envConfig), "utf8");
     }
 
+    process.chdir(cwdDir);
     return await withEnv({
       HOME: homeDir,
       C64BRIDGE_CONFIG: envConfig !== undefined ? envConfigPath : undefined,
       C64_MODE: mode ?? undefined,
     }, fn);
   } finally {
+    process.chdir(previousCwd);
     fs.rmSync(tempRoot, { recursive: true, force: true });
-    if (hadRepoConfig) {
-      fs.writeFileSync(REPO_CONFIG_PATH, originalRepoConfig, "utf8");
-    } else {
-      fs.rmSync(REPO_CONFIG_PATH, { force: true });
-    }
   }
 }
 

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -363,7 +363,40 @@ test("loadConfig supports VICE prewarming via config and env override", (t) => {
   });
 });
 
-test("loadConfig rethrows invalid JSON from configured path", (t) => {
+test("HARD01-006 a project-cwd .c64bridge.json is honoured from a foreign (installed-package-style) working directory", (t) => {
+  const originalEnv = process.env.C64BRIDGE_CONFIG;
+  const originalHome = process.env.HOME;
+  const originalCwd = process.cwd();
+
+  // Simulate the documented npm-installed layout: the server's own module
+  // lives under node_modules, but the project (cwd) has its own config.
+  const projectDir = mkdtempSync(path.join(tmpdir(), "c64-project-cwd-"));
+  const homeDir = mkdtempSync(path.join(tmpdir(), "c64-home-cwd-"));
+  writeFileSync(path.join(projectDir, ".c64bridge.json"), JSON.stringify({ c64u: { host: "project.example" } }, null, 2), "utf8");
+  writeFileSync(path.join(homeDir, ".c64bridge.json"), JSON.stringify({ c64u: { host: "home.example" } }, null, 2), "utf8");
+
+  delete process.env.C64BRIDGE_CONFIG;
+  process.env.HOME = homeDir;
+  process.chdir(projectDir);
+  __resetConfigCacheForTests();
+
+  try {
+    const config = loadConfig();
+    assert.equal(config.c64_host, "project.example");
+    assert.equal(config.baseUrl, "http://project.example");
+  } finally {
+    process.chdir(originalCwd);
+    __resetConfigCacheForTests();
+    if (originalEnv === undefined) delete process.env.C64BRIDGE_CONFIG;
+    else process.env.C64BRIDGE_CONFIG = originalEnv;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("HARD01-027 loadConfig warns and falls back from invalid JSON", (t) => {
   const originalEnv = process.env.C64BRIDGE_CONFIG;
   const { dir, file } = writeTempConfig({ c64u: { host: "placeholder" } });
   writeFileSync(file, "{ invalid json\n", "utf8");
@@ -371,7 +404,7 @@ test("loadConfig rethrows invalid JSON from configured path", (t) => {
   process.env.C64BRIDGE_CONFIG = file;
   __resetConfigCacheForTests();
 
-  assert.throws(() => loadConfig(), /Unexpected token|Expected property name|JSON/);
+  assert.doesNotThrow(() => loadConfig());
 
   t.after(() => {
     __resetConfigCacheForTests();

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "#test/runner";
@@ -215,18 +215,22 @@ test("loadConfig lets C64U env vars override config and defaults", (t) => {
 });
 
 test("loadConfig prefers repo config over home config when env is unset", (t) => {
+  // Isolated cwd rather than the real repo root: several test files exercise
+  // this same "repo/cwd config" scenario concurrently (each in its own
+  // process), and writing to the literal repo-root .c64bridge.json would
+  // race across those processes on the same real file.
   const originalEnv = process.env.C64BRIDGE_CONFIG;
   const originalHome = process.env.HOME;
-  const repoConfigPath = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", ".c64bridge.json");
-  const repoConfigExisted = existsSync(repoConfigPath);
-  const repoConfigContents = repoConfigExisted ? readFileSync(repoConfigPath, "utf8") : null;
+  const originalCwd = process.cwd();
+  const cwdDir = mkdtempSync(path.join(tmpdir(), "c64-cwd-"));
   const homeDir = mkdtempSync(path.join(tmpdir(), "c64-home-"));
 
   writeFileSync(path.join(homeDir, ".c64bridge.json"), JSON.stringify({ c64u: { host: "home.example" } }, null, 2), "utf8");
-  writeFileSync(repoConfigPath, JSON.stringify({ c64u: { host: "repo.example" } }, null, 2), "utf8");
+  writeFileSync(path.join(cwdDir, ".c64bridge.json"), JSON.stringify({ c64u: { host: "repo.example" } }, null, 2), "utf8");
 
   delete process.env.C64BRIDGE_CONFIG;
   process.env.HOME = homeDir;
+  process.chdir(cwdDir);
   __resetConfigCacheForTests();
 
   const config = loadConfig();
@@ -235,6 +239,7 @@ test("loadConfig prefers repo config over home config when env is unset", (t) =>
 
   t.after(() => {
     __resetConfigCacheForTests();
+    process.chdir(originalCwd);
     if (originalEnv === undefined) {
       delete process.env.C64BRIDGE_CONFIG;
     } else {
@@ -245,11 +250,7 @@ test("loadConfig prefers repo config over home config when env is unset", (t) =>
     } else {
       process.env.HOME = originalHome;
     }
-    if (repoConfigExisted && repoConfigContents !== null) {
-      writeFileSync(repoConfigPath, repoConfigContents, "utf8");
-    } else if (existsSync(repoConfigPath)) {
-      unlinkSync(repoConfigPath);
-    }
+    rmSync(cwdDir, { recursive: true, force: true });
     rmSync(homeDir, { recursive: true, force: true });
   });
 });
@@ -257,15 +258,12 @@ test("loadConfig prefers repo config over home config when env is unset", (t) =>
 test("loadConfig falls back to defaults when no config candidates exist", (t) => {
   const originalEnv = process.env.C64BRIDGE_CONFIG;
   const originalHome = process.env.HOME;
-  const repoConfigPath = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", ".c64bridge.json");
-  const repoConfigExisted = existsSync(repoConfigPath);
-  const repoConfigContents = repoConfigExisted ? readFileSync(repoConfigPath, "utf8") : null;
+  const originalCwd = process.cwd();
+  const cwdDir = mkdtempSync(path.join(tmpdir(), "c64-cwd-empty-"));
 
   delete process.env.C64BRIDGE_CONFIG;
   delete process.env.HOME;
-  if (repoConfigExisted) {
-    unlinkSync(repoConfigPath);
-  }
+  process.chdir(cwdDir);
   __resetConfigCacheForTests();
 
   const config = loadConfig();
@@ -277,6 +275,7 @@ test("loadConfig falls back to defaults when no config candidates exist", (t) =>
 
   t.after(() => {
     __resetConfigCacheForTests();
+    process.chdir(originalCwd);
     if (originalEnv === undefined) {
       delete process.env.C64BRIDGE_CONFIG;
     } else {
@@ -287,9 +286,7 @@ test("loadConfig falls back to defaults when no config candidates exist", (t) =>
     } else {
       process.env.HOME = originalHome;
     }
-    if (repoConfigExisted && repoConfigContents !== null) {
-      writeFileSync(repoConfigPath, repoConfigContents, "utf8");
-    }
+    rmSync(cwdDir, { recursive: true, force: true });
   });
 });
 

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -638,11 +638,23 @@ test("device: createFacade with config file", async (t) => {
         assert.equal(debugRead.success, true);
         assert.equal(debugRead.value?.toUpperCase(), "CD");
 
-        const drives = await facade.drivesList();
-        assert.ok(drives && typeof drives === "object");
+        // HARD01-023: the c64u facade must normalise the firmware's
+        // `{ drives: { <id>: info } }` shape into a documented array contract
+        // consumers (drive_mount_and_verify) can rely on across backends.
+        const drivesBefore = await facade.drivesList();
+        assert.ok(Array.isArray(drivesBefore));
+        assert.ok(drivesBefore.every((entry) => "id" in entry && "power" in entry && "image" in entry && "type" in entry));
+
         assert.equal((await facade.driveOn("8")).success, true);
         assert.equal((await facade.driveSetMode("8", "1571")).success, true);
         assert.equal((await facade.driveMount("8", "/tmp/disk.d64", { type: "d64", mode: "readonly" })).success, true);
+
+        const drivesAfterMount = await facade.drivesList();
+        const drive8 = drivesAfterMount.find((entry) => entry.id === "8");
+        assert.ok(drive8, "normalised drives list must include the mounted drive");
+        assert.equal(drive8.power, "on");
+        assert.equal(drive8.image, "/tmp/disk.d64");
+
         assert.equal((await facade.driveLoadRom("8", "/tmp/1541.rom")).success, true);
         assert.equal((await facade.driveReset("8")).success, true);
         assert.equal((await facade.driveRemove("8")).success, true);
@@ -660,6 +672,15 @@ test("device: createFacade with config file", async (t) => {
 
         const fileInfo = await facade.filesInfo("/tmp/demo.prg");
         assert.ok(fileInfo && typeof fileInfo === "object");
+
+        // HARD01-010: nested device paths must keep their `/` separators as
+        // real path separators on the wire, only percent-encoding the
+        // reserved characters within each segment (never encoding `/` as
+        // `%2F`, which the double-encode bug used to do).
+        await facade.filesInfo("/Usb0/demos/new file.d64");
+        assert.match(mock.state.lastRequest.url, /\/v1\/files\/\/Usb0\/demos\/new%20file\.d64:info$/);
+        assert.equal(mock.state.lastRequest.url.includes("%2F"), false);
+
         assert.equal((await facade.filesCreateD64("/tmp/demo.d64", { tracks: 35, diskname: "DEMO" })).success, true);
         assert.equal((await facade.filesCreateD71("/tmp/demo.d71", { diskname: "DEMO71" })).success, true);
         assert.equal((await facade.filesCreateD81("/tmp/demo.d81", { diskname: "DEMO81" })).success, true);
@@ -669,6 +690,46 @@ test("device: createFacade with config file", async (t) => {
         assert.equal((await facade.streamStop("video")).success, true);
 
         assert.equal(mock.state.lastRequest.headers["x-password"], "open-sesame");
+      },
+    );
+  });
+
+  await t.test("HARD01-011 a 200 response carrying a non-empty errors array is treated as failure, not success", async () => {
+    const mock = await startMockC64Server();
+    t.after(async () => {
+      await mock.close();
+    });
+
+    await withConfigScenario(
+      {
+        envConfig: { c64u: { baseUrl: mock.baseUrl } },
+        repoConfig: null,
+        homeConfig: null,
+      },
+      async () => {
+        const { facade } = await createFacade();
+
+        mock.state.forcedErrors = ["Cannot open file"];
+        mock.state.forcedErrorsUrlMatch = "run_prg";
+        const runResult = await facade.runPrg(Buffer.from([0x01, 0x08, 0x00, 0x00]));
+        assert.equal(runResult.success, false);
+        assert.deepEqual(runResult.details.errors, ["Cannot open file"]);
+
+        mock.state.forcedErrors = ["Drive not found"];
+        mock.state.forcedErrorsUrlMatch = "drives/8:mount";
+        const mountResult = await facade.driveMount("8", "/Usb0/demo.d64");
+        assert.equal(mountResult.success, false);
+        assert.deepEqual(mountResult.details.errors, ["Drive not found"]);
+
+        mock.state.forcedErrors = ["Unknown category"];
+        mock.state.forcedErrorsUrlMatch = "/v1/configs/";
+        const configResult = await facade.configSet("bogus", "item", "1");
+        assert.equal(configResult.success, false);
+        assert.deepEqual(configResult.details.errors, ["Unknown category"]);
+
+        // Absence of `errors` (or an empty array) remains a compatible success.
+        const okResult = await facade.runPrg(Buffer.from([0x01, 0x08, 0x00, 0x00]));
+        assert.equal(okResult.success, true);
       },
     );
   });
@@ -695,16 +756,20 @@ test("device: createFacade merges backend sections across config candidates", as
     },
     async () => {
       const { facade, selected, reason } = await createFacade();
-      assert.equal(selected, "vice");
-      assert.equal(reason, "config only");
-      assert.equal(facade.type, "vice");
+      assert.equal(selected, "c64u");
+      assert.match(reason, /fallback/);
+      assert.equal(facade.type, "c64u");
     },
   );
 
+  // HARD01-005: config resolution is single-source-of-truth, not a merge
+  // across candidate files. The winning file (cwd here) must carry every
+  // section a scenario depends on; a section only present in a
+  // lower-precedence file (home) is not consulted.
   await withConfigScenario(
     {
-      repoConfig: { c64u: { host: "repo.local", port: 8081 } },
-      homeConfig: { vice: { host: "127.0.0.1", port: 6509 } },
+      repoConfig: { c64u: { host: "repo.local", port: 8081 }, vice: { host: "127.0.0.1", port: 6509 } },
+      homeConfig: null,
       mode: "vice",
     },
     async () => {
@@ -716,9 +781,11 @@ test("device: createFacade merges backend sections across config candidates", as
     },
   );
 
+  // HARD01-005: the winning envConfig file must carry both sections itself;
+  // a `vice` section only present in repo/home config is not merged in.
   await withConfigScenario(
     {
-      envConfig: { c64u: { host: "env.local", port: 8082 } },
+      envConfig: { c64u: { host: "env.local", port: 8082 }, vice: { exe: "/usr/bin/x64sc" } },
       repoConfig: { c64u: { host: "repo.local", port: 8081 }, vice: { exe: "/usr/bin/x64sc" } },
       homeConfig: { vice: { host: "127.0.0.1", port: 6510 } },
     },
@@ -1057,6 +1124,9 @@ test("device: ViceBackend unit branches", async () => {
         if (name === "Drive11Image") return { type: "string", value: "disk11.d64" };
         if (name === "Drive11Type") return { type: "int", value: 2 };
         if (name === "WarpMode") return { type: "int", value: 1 };
+        if (name === "MachineVideoStandard") return { type: "string", value: "PAL" };
+        if (name === "DriveLabel") return { type: "string", value: "1541" };
+        if (name === "BadSetting") return { type: "string", value: "" };
         throw new Error(`unexpected resource ${name}`);
       },
       async resourceSet(name, value) {
@@ -1093,6 +1163,19 @@ test("device: ViceBackend unit branches", async () => {
     assert.equal(runResult.success, true);
     await assert.rejects(() => backend.runPrg(Buffer.from([0x01])), /PRG data too short/);
 
+    // HARD01-018: runPrg (genuine BASIC/PRG launch) sets BASIC pointers and
+    // types RUN; loadPrg (machine-code entry path) must do neither.
+    assert.ok(calls.some((c) => c[0] === "memSet" && c[1] === 0x002B), "runPrg must set BASIC pointers");
+    assert.ok(calls.some((c) => c[0] === "keyboardFeed" && c[1] === "RUN\r"), "runPrg must type RUN");
+
+    const callsBeforeLoadPrg = calls.length;
+    const loadResult = await backend.loadPrg(Buffer.from([0x00, 0xC0, 0xA9, 0x07, 0x8D, 0x20, 0xD0, 0x60]));
+    assert.equal(loadResult.success, true);
+    const loadPrgCalls = calls.slice(callsBeforeLoadPrg);
+    assert.ok(!loadPrgCalls.some((c) => c[0] === "memSet" && c[1] === 0x002B), "loadPrg must not touch BASIC pointers");
+    assert.ok(!loadPrgCalls.some((c) => c[0] === "keyboardFeed" && c[1] === "RUN\r"), "loadPrg must not type RUN");
+    assert.ok(loadPrgCalls.some((c) => c[0] === "memSet" && c[1] === 0xC000), "loadPrg must place the code at its origin");
+
     const resetResult = await backend.reset();
     const rebootResult = await backend.reboot();
     assert.equal(resetResult.success, true);
@@ -1117,6 +1200,16 @@ test("device: ViceBackend unit branches", async () => {
     await assert.rejects(() => backend.configGet("VICE"), /configGet without item name/);
     assert.equal((await backend.configSet("VICE", "WarpMode", "0")).details.value, 0);
     assert.equal((await backend.configSet("VICE", "MachineVideoStandard", "PAL")).details.value, "PAL");
+
+    // HARD01-035: a string resource whose value happens to be all digits
+    // ("1541") must not be coerced to the integer 1541 merely because it
+    // looks numeric; the resource's declared type governs the payload.
+    const labelResult = await backend.configSet("VICE", "DriveLabel", "1541");
+    assert.equal(labelResult.details.value, "1541");
+    assert.equal(typeof labelResult.details.value, "string");
+    const labelSetCall = calls.find((c) => c[0] === "resourceSet" && c[1] === "DriveLabel");
+    assert.equal(typeof labelSetCall[2], "string");
+    assert.equal(labelSetCall[2], "1541");
 
     const batch = await backend.configBatchUpdate({
       VICE: { WarpMode: "1", BadSetting: "oops" },
@@ -1162,6 +1255,36 @@ test("device: ViceBackend unit branches", async () => {
     };
     assert.equal(await backend.ping(), true);
     assert.equal(pingAttempts, 2);
+  });
+});
+
+test("HARD01-026 ViceBackend.reset reports failure with readiness diagnostics when BASIC never reaches READY", async () => {
+  await withEnv({
+    VICE_TEST_TARGET: "mock",
+    VICE_HOST: "127.0.0.1",
+    VICE_PORT: "6511",
+    C64BRIDGE_VICE_RESET_TIMEOUT_MS: "80",
+  }, async () => {
+    const backend = new ViceBackend({ host: "localhost", port: "6502" });
+    const fakeClient = {
+      async info() {},
+      async memGet() {
+        // Pointers never settle at $0801: reset must not report success.
+        return Buffer.alloc(8);
+      },
+      async memSet() {},
+      async reset() {},
+      async keyboardFeed() {},
+      async exitMonitor() {},
+      close() {},
+    };
+    backend.withClient = async (fn) => fn(fakeClient);
+
+    const result = await backend.reset();
+    assert.equal(result.success, false);
+    assert.equal(result.details.readiness.pointersOk, false);
+    assert.equal(result.details.readiness.promptOk, false);
+    assert.match(result.details.message, /BASIC READY was not observed/);
   });
 });
 

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -29,7 +29,6 @@ const WAIT_READY_INTERVAL_MS = useViceMock ? 25 : 200;
 const WAIT_READY_SCAN_LENGTH = 1_000; // full text screen
 const VICE_PING_TIMEOUT_MS = useViceMock ? 2_000 : (process.env.CI === "1" ? 40_000 : 20_000);
 const VICE_SUITE_TIMEOUT_MS = useViceMock ? 30_000 : (process.env.CI === "1" ? 90_000 : 45_000);
-const REPO_CONFIG_PATH = path.resolve(".c64bridge.json");
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -89,16 +88,21 @@ async function withConfigScenario({
   const envConfigPath = path.join(tempRoot, "env.json");
   const homeDir = path.join(tempRoot, "home");
   const homeConfigPath = path.join(homeDir, ".c64bridge.json");
-  const hadRepoConfig = fs.existsSync(REPO_CONFIG_PATH);
-  const originalRepoConfig = hadRepoConfig ? fs.readFileSync(REPO_CONFIG_PATH, "utf8") : null;
+  // Use an isolated cwd rather than the real repo root: loadConfig() resolves
+  // its "cwd config" candidate from process.cwd() fresh on every call, and
+  // several test files exercise this same scenario concurrently (each in its
+  // own process). Writing to the literal repo-root .c64bridge.json would
+  // race across those processes on the same real file.
+  const cwdDir = path.join(tempRoot, "cwd");
+  const cwdConfigPath = path.join(cwdDir, ".c64bridge.json");
+  const previousCwd = process.cwd();
 
   fs.mkdirSync(homeDir, { recursive: true });
+  fs.mkdirSync(cwdDir, { recursive: true });
 
   try {
-    if (repoConfig === null) {
-      fs.rmSync(REPO_CONFIG_PATH, { force: true });
-    } else if (repoConfig !== undefined) {
-      fs.writeFileSync(REPO_CONFIG_PATH, JSON.stringify(repoConfig), "utf8");
+    if (repoConfig !== null && repoConfig !== undefined) {
+      fs.writeFileSync(cwdConfigPath, JSON.stringify(repoConfig), "utf8");
     }
 
     if (homeConfig !== undefined) {
@@ -113,18 +117,15 @@ async function withConfigScenario({
       fs.writeFileSync(envConfigPath, JSON.stringify(envConfig), "utf8");
     }
 
+    process.chdir(cwdDir);
     return await withEnv({
       HOME: homeDir,
       C64BRIDGE_CONFIG: envConfig !== undefined ? envConfigPath : undefined,
       C64_MODE: mode ?? undefined,
     }, fn);
   } finally {
+    process.chdir(previousCwd);
     fs.rmSync(tempRoot, { recursive: true, force: true });
-    if (hadRepoConfig) {
-      fs.writeFileSync(REPO_CONFIG_PATH, originalRepoConfig, "utf8");
-    } else {
-      fs.rmSync(REPO_CONFIG_PATH, { force: true });
-    }
   }
 }
 

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -750,34 +750,45 @@ test("device: createFacade merges backend sections across config candidates", as
     },
   );
 
-  await withConfigScenario(
-    {
-      repoConfig: {},
-      // A deliberately impossible path: it must never match whatever the
-      // real environment's default-resolved VICE binary happens to be
-      // (e.g. some environments install it at exactly /usr/bin/x64sc).
-      homeConfig: { vice: { exe: "/nonexistent/c64bridge-test-fixture/x64sc" } },
-    },
-    async () => {
-      // HARD01-005: an empty (but present) cwd config file wins outright and
-      // stops the precedence chain, so home's `vice` section must never be
-      // consulted. With no resolved backend config at all, createFacade()
-      // falls through to its live-reachability probe of the default c64u
-      // host, whose outcome is environment-dependent (this sandbox has a
-      // real reachable "c64u" host on its network; a CI runner typically
-      // does not) — so assert the fallback mechanism fired rather than one
-      // specific probe outcome.
-      const { facade, selected, reason } = await createFacade();
-      assert.match(reason, /fallback/);
-      assert.ok(selected === "c64u" || selected === "vice", `unexpected backend: ${selected}`);
-      assert.equal(facade.type, selected);
-      if (selected === "vice") {
-        // The real assertion this scenario exists for: home's vice section
-        // must not have leaked in via merging.
-        assert.notEqual(facade.exe, "/nonexistent/c64bridge-test-fixture/x64sc");
-      }
-    },
-  );
+  // A real, uniquely-named fixture file: unlike a nonexistent path, this
+  // actually exists, so resolveViceBinary()'s findBinary() would return it
+  // verbatim if home's config leaked through — the assertion below can
+  // therefore actually fail on a real leak. A per-run mkdtemp path can never
+  // coincidentally match whatever the environment's default-resolved VICE
+  // binary happens to be (unlike a fixed path such as /usr/bin/x64sc, which
+  // some environments install VICE at).
+  const leakFixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "c64bridge-leak-fixture-"));
+  const leakFixtureExe = path.join(leakFixtureDir, "x64sc");
+  fs.writeFileSync(leakFixtureExe, "", { mode: 0o755 });
+  try {
+    await withConfigScenario(
+      {
+        repoConfig: {},
+        homeConfig: { vice: { exe: leakFixtureExe } },
+      },
+      async () => {
+        // HARD01-005: an empty (but present) cwd config file wins outright and
+        // stops the precedence chain, so home's `vice` section must never be
+        // consulted. With no resolved backend config at all, createFacade()
+        // falls through to its live-reachability probe of the default c64u
+        // host, whose outcome is environment-dependent (this sandbox has a
+        // real reachable "c64u" host on its network; a CI runner typically
+        // does not) — so assert the fallback mechanism fired rather than one
+        // specific probe outcome.
+        const { facade, selected, reason } = await createFacade();
+        assert.match(reason, /fallback/);
+        assert.ok(selected === "c64u" || selected === "vice", `unexpected backend: ${selected}`);
+        assert.equal(facade.type, selected);
+        if (selected === "vice") {
+          // The real assertion this scenario exists for: home's vice section
+          // must not have leaked in via merging.
+          assert.notEqual(facade.exe, leakFixtureExe);
+        }
+      },
+    );
+  } finally {
+    fs.rmSync(leakFixtureDir, { recursive: true, force: true });
+  }
 
   // HARD01-005: config resolution is single-source-of-truth, not a merge
   // across candidate files. The winning file (cwd here) must carry every

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -753,7 +753,10 @@ test("device: createFacade merges backend sections across config candidates", as
   await withConfigScenario(
     {
       repoConfig: {},
-      homeConfig: { vice: { exe: "/usr/bin/x64sc" } },
+      // A deliberately impossible path: it must never match whatever the
+      // real environment's default-resolved VICE binary happens to be
+      // (e.g. some environments install it at exactly /usr/bin/x64sc).
+      homeConfig: { vice: { exe: "/nonexistent/c64bridge-test-fixture/x64sc" } },
     },
     async () => {
       // HARD01-005: an empty (but present) cwd config file wins outright and
@@ -770,8 +773,8 @@ test("device: createFacade merges backend sections across config candidates", as
       assert.equal(facade.type, selected);
       if (selected === "vice") {
         // The real assertion this scenario exists for: home's vice section
-        // (exe: "/usr/bin/x64sc") must not have leaked in via merging.
-        assert.notEqual(facade.exe, "/usr/bin/x64sc");
+        // must not have leaked in via merging.
+        assert.notEqual(facade.exe, "/nonexistent/c64bridge-test-fixture/x64sc");
       }
     },
   );

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -756,10 +756,23 @@ test("device: createFacade merges backend sections across config candidates", as
       homeConfig: { vice: { exe: "/usr/bin/x64sc" } },
     },
     async () => {
+      // HARD01-005: an empty (but present) cwd config file wins outright and
+      // stops the precedence chain, so home's `vice` section must never be
+      // consulted. With no resolved backend config at all, createFacade()
+      // falls through to its live-reachability probe of the default c64u
+      // host, whose outcome is environment-dependent (this sandbox has a
+      // real reachable "c64u" host on its network; a CI runner typically
+      // does not) — so assert the fallback mechanism fired rather than one
+      // specific probe outcome.
       const { facade, selected, reason } = await createFacade();
-      assert.equal(selected, "c64u");
       assert.match(reason, /fallback/);
-      assert.equal(facade.type, "c64u");
+      assert.ok(selected === "c64u" || selected === "vice", `unexpected backend: ${selected}`);
+      assert.equal(facade.type, selected);
+      if (selected === "vice") {
+        // The real assertion this scenario exists for: home's vice section
+        // (exe: "/usr/bin/x64sc") must not have leaked in via merging.
+        assert.notEqual(facade.exe, "/usr/bin/x64sc");
+      }
     },
   );
 

--- a/test/groupedToolsShims.test.mjs
+++ b/test/groupedToolsShims.test.mjs
@@ -163,6 +163,47 @@ test("c64_program c64u-only grouped operations reject on vice", async () => {
   }
 });
 
+test("HARD01-034 c64_printer is available on u2 (matching the advertised printer-integration feature), not just c64u", async () => {
+  const stubClient = {
+    async printTextOnPrinterAndRun() {
+      return { success: true, details: { basic: "10 OPEN1,4\n20 PRINT#1,\"HELLO\"\n30 CLOSE1" } };
+    },
+  };
+  const ctx = {
+    client: stubClient,
+    rag: {},
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    platform: { id: "u2", features: [], limitedFeatures: [] },
+    setPlatform,
+  };
+
+  const result = await toolRegistry.invoke("c64_printer", { op: "print_text", text: "HELLO" }, ctx);
+  assert.equal(result.isError, undefined);
+});
+
+test("c64_printer remains unavailable on vice (no printer hardware)", async () => {
+  const ctx = {
+    client: {
+      async printTextOnPrinterAndRun() {
+        throw new Error("should not execute on unsupported platform");
+      },
+    },
+    rag: {},
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    platform: { id: "vice", features: [], limitedFeatures: [] },
+    setPlatform,
+  };
+
+  await assert.rejects(
+    () => toolRegistry.invoke("c64_printer", { op: "print_text", text: "HELLO" }, ctx),
+    (error) => {
+      assert.ok(error instanceof ToolUnsupportedPlatformError);
+      assert.equal(error.platform, "vice");
+      return true;
+    },
+  );
+});
+
 test("c64_program upload_run_basic uses shared BASIC handler", async () => {
   const uploads = [];
   let screenReads = 0;

--- a/test/inputModule.test.mjs
+++ b/test/inputModule.test.mjs
@@ -32,6 +32,9 @@ function createInputContext({ platformId = "c64u", recorder } = {}) {
       const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
       writes.push({ kind: "vice_mem_set", address, bytes: Uint8Array.from(buf) });
     },
+    async viceJoyportSet(port, activeLowMask) {
+      writes.push({ kind: "vice_joyport_set", port, activeLowMask });
+    },
     async readMemoryRaw(address, length) {
       reads.push({ address, length });
       return new Uint8Array(length);
@@ -154,7 +157,7 @@ test("c64_input.key accepts single printable characters and reports duration met
   assert.deepEqual(Array.from(inject.bytes), [65]);
 });
 
-test("c64_input.joystick uses native REST input on c64u and VICE memory on vice", async () => {
+test("HARD01-014 c64_input.joystick uses native REST input on c64u and Joyport Set on vice", async () => {
   const { ctx: c64uCtx, inputBatches } = createInputContext({ platformId: "c64u" });
   const c64uResult = await toolRegistry.invoke("c64_input", {
     op: "joystick", port: 2, controls: ["right", "fire2"], action: "press",
@@ -167,9 +170,7 @@ test("c64_input.joystick uses native REST input on c64u and VICE memory on vice"
     op: "joystick", port: 2, controls: ["right"], action: "press",
   }, viceCtx);
   assert.equal(result.isError, undefined);
-  const memSet = writes.find((w) => w.kind === "vice_mem_set");
-  assert.ok(memSet, "joystick press must perform a memory write");
-  assert.equal(memSet.address, 0xDC00);
+  assert.deepEqual(writes.find((w) => w.kind === "vice_joyport_set"), { kind: "vice_joyport_set", port: 2, activeLowMask: 0xF7 });
 });
 
 test("c64_input.joystick maps an empty C64U release to the REST release_all event", async () => {
@@ -220,13 +221,13 @@ test("c64_input.joystick supports release and tap actions on vice", async () => 
 
   assert.equal(releaseResult.isError, undefined);
   assert.equal(tapResult.isError, undefined);
-  const viceWrites = writes.filter((w) => w.kind === "vice_mem_set");
+  const viceWrites = writes.filter((w) => w.kind === "vice_joyport_set");
   assert.deepEqual(
-    viceWrites.map((entry) => ({ address: entry.address, bytes: Array.from(entry.bytes) })),
+    viceWrites.map((entry) => ({ port: entry.port, activeLowMask: entry.activeLowMask })),
     [
-      { address: 0xDC01, bytes: [0xFF] },
-      { address: 0xDC00, bytes: [0xEE] },
-      { address: 0xDC00, bytes: [0xFF] },
+      { port: 1, activeLowMask: 0xFF },
+      { port: 2, activeLowMask: 0xEE },
+      { port: 2, activeLowMask: 0xFF },
     ],
   );
 });

--- a/test/keyboardInjection.test.mjs
+++ b/test/keyboardInjection.test.mjs
@@ -92,7 +92,7 @@ test("injectKeyboardQueue accepts numeric arrays and Buffers", async () => {
   assert.deepEqual(Array.from(queueWrites[1].bytes), [0x43]);
 });
 
-test("injectKeyboardQueue gives up after drainTimeoutMs and continues", async () => {
+test("HARD01-009 injectKeyboardQueue reports a drain timeout without overwriting input", async () => {
   // Force NDX never to clear so the helper has to bail out on its own timeout.
   const facade = createTrackingFacade({ ndxRef: { value: 1 }, autoDrain: false });
   // Override readMemory to always return non-zero
@@ -100,14 +100,43 @@ test("injectKeyboardQueue gives up after drainTimeoutMs and continues", async ()
   const client = makeClient(facade);
 
   const start = Date.now();
-  await client.injectKeyboardQueue(Uint8Array.of(0x41, 0x42), {
+  await assert.rejects(() => client.injectKeyboardQueue(Uint8Array.of(0x41, 0x42), {
     drainPollMs: 5,
     drainTimeoutMs: 60,
-  });
+  }), /did not drain/);
   const elapsed = Date.now() - start;
   assert.ok(elapsed >= 50, `expected drain wait to elapse, got ${elapsed}ms`);
-  // Even with a stuck queue the writes must still have happened.
+  // The first chunk was queued, but no later chunk can overwrite it.
   assert.ok(facade.writes.find((w) => w.address === 0x0277));
+});
+
+test("HARD01-004 a transient machine:input probe failure does not permanently cache 'unknown'", async () => {
+  let calls = 0;
+  const facade = {
+    ...createTrackingFacade(),
+    async getInputState() {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("ECONNRESET");
+      }
+      return { keyboard: { inputs: [] }, joysticks: [] };
+    },
+  };
+  const client = makeClient(facade);
+
+  const first = await client.getNativeEndpointCapabilities();
+  assert.equal(first.machineInput, "unknown");
+
+  // A transient network error must not be baked into the cache: the very
+  // next read should retry rather than returning the stale "unknown".
+  const second = await client.getNativeEndpointCapabilities();
+  assert.equal(second.machineInput, "available");
+  assert.equal(calls, 2, "expected the probe to run again after an unknown result");
+
+  // And once a confirmed result exists, it stays cached (no further probes).
+  const third = await client.getNativeEndpointCapabilities();
+  assert.equal(third.machineInput, "available");
+  assert.equal(calls, 2, "a confirmed result must not be re-probed");
 });
 
 test("writeMemoryRaw delegates to facade.writeMemory", async () => {
@@ -119,7 +148,7 @@ test("writeMemoryRaw delegates to facade.writeMemory", async () => {
   assert.deepEqual(Array.from(write.bytes), [0xDE, 0xAD]);
 });
 
-test("powerCycle verifies every C64U Tool Menu transition before selecting Power Cycle", async () => {
+test("HARD01-002 powerCycle fails closed when menu highlight cannot be verified", async () => {
   const inputs = [];
   const screens = [
     Buffer.from("MAIN MENU"),
@@ -140,11 +169,59 @@ test("powerCycle verifies every C64U Tool Menu transition before selecting Power
   const client = makeClient(facade);
   const result = await client.powerCycle();
 
-  assert.equal(result.success, true);
+  assert.equal(result.success, false);
   assert.deepEqual(inputs.map(({ events }) => events[0].inputs), [
-    ["f1"], ["return"], ["cursor_up_down"], ["cursor_up_down"], ["cursor_up_down"], ["cursor_up_down"], ["return"],
+    ["f1"], ["return"], ["cursor_up_down"], ["cursor_up_down"], ["cursor_up_down"], ["cursor_up_down"],
   ]);
-  assert.equal(result.details.strategy, "tool_menu");
+  assert.ok(result.details.cleanup);
+});
+
+test("HARD01-003 powerCycle attempts a best-effort menu close after a mid-flow failure, but not before the menu opened", async () => {
+  const menuButtonCalls = [];
+  const screens = [
+    Buffer.from("MAIN MENU"),
+    Buffer.from("TOOL MENU"),
+    Buffer.from("TOOL MENU  POWER CYCLE"),
+    Buffer.from("TOOL MENU  POWER CYCLE  1"),
+    Buffer.from("TOOL MENU  POWER CYCLE  2"),
+    Buffer.from("TOOL MENU  POWER CYCLE  3"),
+    Buffer.from("TOOL MENU  POWER CYCLE  4"),
+  ];
+  const facade = {
+    ...createTrackingFacade(),
+    async menuButton() { menuButtonCalls.push(Date.now()); return { success: true }; },
+    async getInputState() { return { keyboard: { inputs: [] }, joysticks: [] }; },
+    async readMenuScreen() { return Uint8Array.from(screens.shift()); },
+    async sendInputEvents(batch) { return { keyboard: { inputs: [] }, joysticks: [] }; },
+  };
+  const client = makeClient(facade);
+  const result = await client.powerCycle();
+
+  assert.equal(result.success, false);
+  // menuButton is called once to open the menu and once more, on failure, to
+  // attempt a best-effort close.
+  assert.equal(menuButtonCalls.length, 2, "expected the initial open call plus one cleanup call");
+  assert.equal(result.details.cleanup.success, true);
+});
+
+test("HARD01-003 powerCycle does not attempt cleanup when the menu was never opened", async () => {
+  const menuButtonCalls = [];
+  const facade = {
+    ...createTrackingFacade(),
+    async menuButton() { menuButtonCalls.push(1); throw new Error("menu open failed"); },
+    async getInputState() { return { keyboard: { inputs: [] }, joysticks: [] }; },
+    async readMenuScreen() { return Uint8Array.from(Buffer.from("MAIN MENU")); },
+    async sendInputEvents(batch) { return { keyboard: { inputs: [] }, joysticks: [] }; },
+  };
+  const client = makeClient(facade);
+  const result = await client.powerCycle();
+
+  assert.equal(result.success, false);
+  // The single menuButton call above is the (failing) attempt to open the
+  // menu itself, not a cleanup call: since opening never succeeded, no
+  // separate close attempt should be issued.
+  assert.equal(menuButtonCalls.length, 1, "expected only the failed open attempt, no cleanup call");
+  assert.equal(result.details.cleanup.details, "menu cleanup was not attempted");
 });
 
 test("powerCycle uses reboot for U2-family cartridges", async () => {

--- a/test/knowledge.test.mjs
+++ b/test/knowledge.test.mjs
@@ -30,6 +30,13 @@ test("knowledge helpers expose stable symbols and memory regions", () => {
   assert.ok(memoryMap.some((entry) => entry.name === "sid_registers"));
 });
 
+test("HARD01-032 the BASIC spec's documented SID frequency formula matches the 24-bit phase accumulator, not the old 2^16 formula", () => {
+  const spec = getBasicV2Spec();
+  assert.match(spec, /freq_value = round\(\(frequency_Hz.*16777216.*clock_rate\)/);
+  assert.equal(spec.includes("× 65536"), false);
+  assert.equal(spec.includes("x 65536"), false);
+});
+
 test("knowledge search returns BASIC, ASM, and VIC-II sections", () => {
   const basicSpec = getBasicV2Spec();
   assert.match(basicSpec, /Commodore BASIC v2/i);

--- a/test/loggingHttpClient.test.mjs
+++ b/test/loggingHttpClient.test.mjs
@@ -130,6 +130,50 @@ test("response interceptor logs with debug enabled", () => {
   assert.ok(debugLogs.some(log => log.includes("response")));
 });
 
+test("HARD01-024 the request interceptor redacts X-Password (case-insensitively) before it ever reaches metadata/logs", () => {
+  const logger = createMockLogger();
+  const client = createLoggingHttpClient({ baseURL: "http://localhost" }, logger);
+
+  const requestConfig = {
+    method: "put",
+    url: "/v1/machine:reset",
+    headers: { "X-Password": "super-secret", Accept: "application/json" },
+  };
+
+  const intercepted = client.instance.interceptors.request.handlers[0].fulfilled(requestConfig);
+  assert.equal(intercepted.__c64Meta.headers["X-Password"], "***");
+  assert.equal(intercepted.__c64Meta.headers.Accept, "application/json");
+  assert.equal(JSON.stringify(intercepted.__c64Meta).includes("super-secret"), false);
+});
+
+test("HARD01-024 debug response/error logging never emits the raw X-Password value", () => {
+  const logger = createDebugLogger();
+  const client = createLoggingHttpClient({ baseURL: "http://localhost" }, logger);
+
+  // Route through the real request interceptor first, exactly as axios
+  // would, so __c64Meta.headers reflects genuine redacted production state
+  // rather than a hand-crafted (and therefore unrealistic) test double.
+  const requestConfig = client.instance.interceptors.request.handlers[0].fulfilled({
+    method: "get",
+    url: "/v1/info",
+    headers: { "x-password": "super-secret" },
+  });
+
+  const response = {
+    status: 200,
+    data: { ok: true },
+    config: requestConfig,
+    headers: { "x-password": "super-secret", "content-type": "application/json" },
+  };
+
+  client.instance.interceptors.response.handlers[0].fulfilled(response);
+
+  const allDebugLogs = logger.logs.debug.map((entry) => JSON.stringify(entry));
+  assert.ok(allDebugLogs.every((entry) => !entry.includes("super-secret")));
+  const responseLog = logger.logs.debug.find((entry) => entry[0].includes("response"));
+  assert.equal(responseLog[1].headers["x-password"], "***");
+});
+
 test("response interceptor handles missing metadata", () => {
   const logger = createMockLogger();
   const client = createLoggingHttpClient({ baseURL: "http://localhost" }, logger);

--- a/test/mcpServerCli.test.mjs
+++ b/test/mcpServerCli.test.mjs
@@ -15,9 +15,15 @@ const tsLoader = "tsx/esm";
 // mcp-server.ts auto-starts a live server on import unless opted out (it is
 // always imported as a side effect by src/index.ts in real deployments, so
 // it cannot gate on "am I the entrypoint"). A plain top-level `import`
-// would run before this opt-out could be set, so load it dynamically.
+// would run before this opt-out could be set, so load it dynamically. The
+// override must be restored immediately: every test file in this repo's Bun
+// runs share one process, and leaving this set would silently disable
+// auto-start for every server spawned by unrelated test files afterward.
+const previousSkipAutoStart = process.env.C64BRIDGE_SKIP_AUTO_START;
 process.env.C64BRIDGE_SKIP_AUTO_START = "1";
 const { parseCliOptions } = await import("../src/mcp-server.js");
+if (previousSkipAutoStart === undefined) delete process.env.C64BRIDGE_SKIP_AUTO_START;
+else process.env.C64BRIDGE_SKIP_AUTO_START = previousSkipAutoStart;
 
 test("HARD01-001 parseCliOptions honours --http and its optional port", () => {
   assert.deepEqual(parseCliOptions([]), { mode: "stdio" });
@@ -78,6 +84,31 @@ async function waitFor(predicate, { timeoutMs = 10_000, intervalMs = 50 } = {}) 
   throw new Error("condition not met before timeout");
 }
 
+// Bun's test runner executes every file in one shared process, so a spawned
+// child that outlives its own test can still be shutting down while later
+// files start their own servers. Wait for a real exit (escalating to
+// SIGKILL) rather than firing SIGTERM and moving on.
+async function stopChild(child, timeoutMs = 5_000) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    child.once("exit", done);
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      if (settled) return;
+      try { child.kill("SIGKILL"); } catch {}
+      setTimeout(done, 200);
+    }, timeoutMs);
+  });
+}
+
 test("HARD01-001 --http <port> opens a real HTTP MCP listener; default invocation stays on stdio", async (t) => {
   const mock = await startMockC64Server();
   t.after(async () => { await mock.close(); });
@@ -97,7 +128,7 @@ test("HARD01-001 --http <port> opens a real HTTP MCP listener; default invocatio
   };
 
   const { child, getStderr } = spawnServer(["--http", String(port)], env);
-  t.after(() => { if (!child.killed) child.kill("SIGTERM"); });
+  t.after(() => stopChild(child));
 
   try {
     await waitFor(() => getStderr().includes("running on HTTP"), { timeoutMs: 15_000 });
@@ -121,6 +152,6 @@ test("HARD01-001 --http <port> opens a real HTTP MCP listener; default invocatio
     // listener at all (any HTTP status), not the specific status code.
     assert.ok(typeof response.status === "number" && response.status > 0);
   } finally {
-    child.kill("SIGTERM");
+    await stopChild(child);
   }
 });

--- a/test/mcpServerCli.test.mjs
+++ b/test/mcpServerCli.test.mjs
@@ -1,0 +1,126 @@
+import test from "#test/runner";
+import assert from "#test/assert";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { startMockC64Server } from "../scripts/mockC64Server.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const tsLoader = "tsx/esm";
+
+// mcp-server.ts auto-starts a live server on import unless opted out (it is
+// always imported as a side effect by src/index.ts in real deployments, so
+// it cannot gate on "am I the entrypoint"). A plain top-level `import`
+// would run before this opt-out could be set, so load it dynamically.
+process.env.C64BRIDGE_SKIP_AUTO_START = "1";
+const { parseCliOptions } = await import("../src/mcp-server.js");
+
+test("HARD01-001 parseCliOptions honours --http and its optional port", () => {
+  assert.deepEqual(parseCliOptions([]), { mode: "stdio" });
+  assert.deepEqual(parseCliOptions(["--foo", "bar"]), { mode: "stdio" });
+  assert.deepEqual(parseCliOptions(["--http"]), { mode: "http", port: undefined });
+  assert.deepEqual(parseCliOptions(["--http", "8080"]), { mode: "http", port: 8080 });
+  assert.deepEqual(parseCliOptions(["--http", "--other-flag"]), { mode: "http", port: undefined });
+  assert.deepEqual(parseCliOptions(["--http", "not-a-port"]), { mode: "http", port: undefined });
+  assert.deepEqual(parseCliOptions(["--http", "0"]), { mode: "http", port: undefined });
+  assert.deepEqual(parseCliOptions(["--http", "70000"]), { mode: "http", port: undefined });
+});
+
+async function reserveLoopbackPort() {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) reject(error);
+        else if (!port) reject(new Error("failed to reserve a loopback port"));
+        else resolve(port);
+      });
+    });
+  });
+}
+
+function spawnServer(args, env) {
+  const child = spawn(
+    process.execPath,
+    ["--import", tsLoader, path.join(repoRoot, "src", "mcp-server.ts"), ...args],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        // The parent test process opts itself out of auto-start (see the
+        // dynamic import above); the spawned child must still start for real.
+        C64BRIDGE_SKIP_AUTO_START: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  return { child, getStderr: () => stderr };
+}
+
+async function waitFor(predicate, { timeoutMs = 10_000, intervalMs = 50 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("condition not met before timeout");
+}
+
+test("HARD01-001 --http <port> opens a real HTTP MCP listener; default invocation stays on stdio", async (t) => {
+  const mock = await startMockC64Server();
+  t.after(async () => { await mock.close(); });
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "c64bridge-http-cli-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  const configPath = path.join(tempRoot, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify({ c64u: { baseUrl: mock.baseUrl } }), "utf8");
+  const homeDir = path.join(tempRoot, "home");
+  fs.mkdirSync(homeDir, { recursive: true });
+
+  const port = await reserveLoopbackPort();
+  const env = {
+    C64BRIDGE_CONFIG: configPath,
+    HOME: homeDir,
+    C64_TEST_TARGET: "mock",
+  };
+
+  const { child, getStderr } = spawnServer(["--http", String(port)], env);
+  t.after(() => { if (!child.killed) child.kill("SIGTERM"); });
+
+  try {
+    await waitFor(() => getStderr().includes("running on HTTP"), { timeoutMs: 15_000 });
+
+    const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "hard01-001-test", version: "0.0.0" },
+        },
+      }),
+    });
+
+    // The important assertion is that the request reached a real HTTP
+    // listener at all (any HTTP status), not the specific status code.
+    assert.ok(typeof response.status === "number" && response.status > 0);
+  } finally {
+    child.kill("SIGTERM");
+  }
+});

--- a/test/mcpServerPlatformInit.test.mjs
+++ b/test/mcpServerPlatformInit.test.mjs
@@ -85,8 +85,6 @@ async function withServerConfigOnce(config, env, fn) {
   const configPath = path.join(tempRoot, "c64bridge.json");
   const diagnosticsDir = path.join(tempRoot, "diagnostics");
   const homeDir = path.join(tempRoot, "home");
-  const hadRepoConfig = fs.existsSync(REPO_CONFIG_PATH);
-  const originalRepoConfig = hadRepoConfig ? fs.readFileSync(REPO_CONFIG_PATH, "utf8") : null;
   fs.mkdirSync(diagnosticsDir, { recursive: true });
   fs.mkdirSync(homeDir, { recursive: true });
   fs.writeFileSync(configPath, JSON.stringify(config), "utf8");
@@ -99,7 +97,10 @@ async function withServerConfigOnce(config, env, fn) {
   process.prependListener("uncaughtException", swallowSocketReset);
 
   try {
-    fs.rmSync(REPO_CONFIG_PATH, { force: true });
+    // C64BRIDGE_CONFIG (highest precedence) always pins the spawned server
+    // to this scenario's isolated config file, so the real repo-root
+    // .c64bridge.json is never consulted and must not be touched here:
+    // other test files exercise that same real file concurrently.
     const connection = await createConnectedClient({
       env: {
         C64BRIDGE_CONFIG: configPath,
@@ -124,11 +125,6 @@ async function withServerConfigOnce(config, env, fn) {
   } finally {
     await delay(50);
     process.removeListener("uncaughtException", swallowSocketReset);
-    if (hadRepoConfig) {
-      fs.writeFileSync(REPO_CONFIG_PATH, originalRepoConfig, "utf8");
-    } else {
-      fs.rmSync(REPO_CONFIG_PATH, { force: true });
-    }
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 }

--- a/test/mcpServerPlatformStatusResource.test.mjs
+++ b/test/mcpServerPlatformStatusResource.test.mjs
@@ -4,9 +4,15 @@ import assert from "#test/assert";
 // mcp-server.ts auto-starts a live server on import unless opted out (it is
 // always imported as a side effect by src/index.ts in real deployments, so
 // it cannot gate on "am I the entrypoint"). A plain top-level `import` would
-// run before this opt-out could be set, so load it dynamically instead.
+// run before this opt-out could be set, so load it dynamically instead. The
+// override must be restored immediately: every test file in this repo's Bun
+// runs share one process, and leaving this set would silently disable
+// auto-start for every server spawned by unrelated test files afterward.
+const previousSkipAutoStart = process.env.C64BRIDGE_SKIP_AUTO_START;
 process.env.C64BRIDGE_SKIP_AUTO_START = "1";
 const { renderPlatformStatusMarkdown } = await import("../src/mcp-server.js");
+if (previousSkipAutoStart === undefined) delete process.env.C64BRIDGE_SKIP_AUTO_START;
+else process.env.C64BRIDGE_SKIP_AUTO_START = previousSkipAutoStart;
 
 function createFakeClient(overrides = {}) {
   return {

--- a/test/mcpServerPlatformStatusResource.test.mjs
+++ b/test/mcpServerPlatformStatusResource.test.mjs
@@ -1,0 +1,49 @@
+import test from "#test/runner";
+import assert from "#test/assert";
+
+// mcp-server.ts auto-starts a live server on import unless opted out (it is
+// always imported as a side effect by src/index.ts in real deployments, so
+// it cannot gate on "am I the entrypoint"). A plain top-level `import` would
+// run before this opt-out could be set, so load it dynamically instead.
+process.env.C64BRIDGE_SKIP_AUTO_START = "1";
+const { renderPlatformStatusMarkdown } = await import("../src/mcp-server.js");
+
+function createFakeClient(overrides = {}) {
+  return {
+    getAvailableBackends() {
+      return ["c64u"];
+    },
+    async getNativeEndpointCapabilities() {
+      return { machineInput: "available", machineMenuScreen: "unknown" };
+    },
+    ...overrides,
+  };
+}
+
+test("HARD01-031 renderPlatformStatusMarkdown returns quickly even when the machine:input probe never resolves", async () => {
+  const client = createFakeClient({
+    async getNativeEndpointCapabilities() {
+      // Simulate an unreachable/booting Ultimate: the probe never settles.
+      return new Promise(() => {});
+    },
+  });
+
+  const start = Date.now();
+  const markdown = await renderPlatformStatusMarkdown(client);
+  const elapsed = Date.now() - start;
+
+  // Must return well inside the 10s facade HTTP timeout; the resource is
+  // documented as a cheap, side-effect-free metadata read.
+  assert.ok(elapsed < 2_000, `expected a fast bounded response, took ${elapsed}ms`);
+  assert.match(markdown, /machine:input.*\*\*unknown\*\*/s);
+});
+
+test("renderPlatformStatusMarkdown reports a confirmed capability without waiting for the timeout", async () => {
+  const client = createFakeClient();
+  const start = Date.now();
+  const markdown = await renderPlatformStatusMarkdown(client);
+  const elapsed = Date.now() - start;
+
+  assert.ok(elapsed < 500, `expected an immediate response, took ${elapsed}ms`);
+  assert.match(markdown, /machine:input.*\*\*available\*\*/s);
+});

--- a/test/memory.test.mjs
+++ b/test/memory.test.mjs
@@ -35,6 +35,7 @@ function createMockClient(overrides = {}) {
     },
     async pause() { return { success: true }; },
     async resume() { return { success: true }; },
+    async pinFacade() { return { type: "mock" }; },
     ...overrides,
   };
 }
@@ -424,6 +425,55 @@ testC64uOnly("write verifies written bytes when verify flag is set", async () =>
   assert.ok(events.includes("resume"));
 });
 
+testC64uOnly("HARD01-016 write-verify pins the facade so a concurrent backend switch cannot retarget an in-flight step", async () => {
+  const events = [];
+  let activeFacadeType = "vice";
+  const viceFacade = { type: "vice" };
+  const c64uFacade = { type: "c64u" };
+
+  const ctx = {
+    client: createMockClient({
+      async pinFacade() {
+        return activeFacadeType === "vice" ? viceFacade : c64uFacade;
+      },
+      async pause(facade) {
+        events.push({ op: "pause", facade: facade?.type });
+        // Simulate a concurrent c64_select_backend firing between steps.
+        activeFacadeType = "c64u";
+        return { success: true };
+      },
+      readCount: 0,
+      async readMemory(address, length, facade) {
+        this.readCount += 1;
+        events.push({ op: `read-${this.readCount}`, facade: facade?.type });
+        return {
+          success: true,
+          data: this.readCount === 1 ? "$0000" : "$AABB",
+          details: { address: "0400", length: Number(length) },
+        };
+      },
+      async writeMemory(address, bytes, facade) {
+        events.push({ op: "write", facade: facade?.type });
+        return { success: true, details: { address: "0400", length: 2 } };
+      },
+      async resume(facade) {
+        events.push({ op: "resume", facade: facade?.type });
+        return { success: true };
+      },
+    }),
+    logger: createLogger(),
+  };
+
+  const res = await memoryModule.invoke("write", { address: "$0400", bytes: "$AABB", verify: true }, ctx);
+
+  assert.equal(res.metadata?.success, true);
+  assert.equal(res.metadata?.verified, true);
+  // Every step must use the facade pinned at the start of the invocation
+  // (vice), never the one made active by the mid-flight switch (c64u).
+  assert.ok(events.every((event) => event.facade === "vice"), JSON.stringify(events));
+  assert.deepEqual(events.map((event) => event.op), ["pause", "read-1", "write", "read-2", "resume"]);
+});
+
 testC64uOnly("write aborts when expected bytes mismatch and abortOnMismatch is true", async () => {
   const events = [];
   const ctx = {
@@ -567,6 +617,36 @@ testC64uOnly("write verification fails when pause fails", async () => {
 
   assert.equal(res.isError, true);
   assert.equal(res.metadata?.error?.kind, "execution");
+});
+
+testC64uOnly("HARD01-017 a successful write-verify that cannot resume the machine reports failure, not a clean success", async () => {
+  const ctx = {
+    client: createMockClient({
+      readCount: 0,
+      async pause() { return { success: true }; },
+      async resume() { return { success: false, details: "firmware timeout" }; },
+      async readMemory(_address, length) {
+        this.readCount += 1;
+        if (this.readCount === 1) {
+          return { success: true, data: "$0000", details: { address: "0400", length: Number(length) } };
+        }
+        return { success: true, data: "$AABB", details: { address: "0400", length: Number(length) } };
+      },
+      async writeMemory() {
+        return { success: true, details: { address: "0400", length: 2 } };
+      },
+    }),
+    logger: createLogger(),
+  };
+
+  const res = await memoryModule.invoke("write", { address: "$0400", bytes: "$AABB", verify: true }, ctx);
+
+  // The write itself was verified successfully, but the machine could not
+  // be resumed: this must surface as an actionable failure, not success.
+  assert.equal(res.isError, true);
+  assert.equal(res.metadata?.error?.kind, "execution");
+  assert.equal(res.metadata?.error?.details?.machinePaused, true);
+  assert.ok(String(res.metadata?.error?.details?.recovery ?? "").includes("resume"));
 });
 
 testC64uOnly("write verification handles malformed firmware reads and writeback failures", async () => {

--- a/test/meta/artifacts.test.mjs
+++ b/test/meta/artifacts.test.mjs
@@ -1,5 +1,7 @@
 import test from "#test/runner";
 import assert from "#test/assert";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { metaModule } from "../../src/tools/meta/index.js";
 import { createLogger, tmpPath } from "./helpers.mjs";
 
@@ -66,4 +68,55 @@ test("bundle_run_artifacts handles errors gracefully", async () => {
   }, ctx);
 
   assert.equal(res.isError, true);
+});
+
+test("HARD01-029 bundle_run_artifacts rejects a traversal runId and creates nothing outside outputPath", async () => {
+  const { dir } = tmpPath("artifacts", "traversal");
+  const ctx = {
+    client: {
+      async readScreen() { return "SCREEN"; },
+      async debugregRead() { return { value: "0000" }; },
+    },
+    logger: createLogger(),
+  };
+  const escapeTarget = path.resolve(dir, "..", "escape");
+  await fs.rm(escapeTarget, { recursive: true, force: true });
+
+  const res = await metaModule.invoke("bundle_run_artifacts", {
+    runId: "../escape",
+    outputPath: dir,
+    captureScreen: true,
+  }, ctx);
+
+  assert.equal(res.isError, true);
+  const escapeExists = await fs.access(escapeTarget).then(() => true, () => false);
+  assert.equal(escapeExists, false, "runId traversal must not create a directory outside outputPath");
+});
+
+test("HARD01-029 bundle_run_artifacts rejects an absolute-path and sibling-prefix-escaping runId", async () => {
+  const { dir } = tmpPath("artifacts", "traversal-abs");
+  const ctx = {
+    client: {
+      async readScreen() { return "SCREEN"; },
+    },
+    logger: createLogger(),
+  };
+
+  const absoluteResult = await metaModule.invoke("bundle_run_artifacts", {
+    runId: "/etc/passwd",
+    outputPath: dir,
+  }, ctx);
+  assert.equal(absoluteResult.isError, true);
+
+  // outputPath "dir" has a sibling "dir-evil" that a naive string-prefix
+  // check on the resolved path would incorrectly treat as contained.
+  const siblingDir = `${dir}-evil`;
+  await fs.rm(siblingDir, { recursive: true, force: true });
+  const siblingResult = await metaModule.invoke("bundle_run_artifacts", {
+    runId: "..",
+    outputPath: dir,
+  }, ctx);
+  assert.equal(siblingResult.isError, true);
+  const siblingExists = await fs.access(siblingDir).then(() => true, () => false);
+  assert.equal(siblingExists, false);
 });

--- a/test/meta/background.test.mjs
+++ b/test/meta/background.test.mjs
@@ -217,6 +217,40 @@ test("background tasks persist task errors and reuse ids when restarted", async 
   }
 });
 
+test("HARD01-028 a background iteration that resolves {success:false} is recorded as a failure, not counted as healthy", async () => {
+  const { file, dir } = tmpPath("background-resolved-failure", "tasks.json");
+  await fs.mkdir(dir, { recursive: true });
+  const previous = process.env.C64_TASK_STATE_FILE;
+  process.env.C64_TASK_STATE_FILE = file;
+  try {
+    const ctx = {
+      client: {
+        async readMemory() {
+          // Resolved (not thrown) failure, as C64Client methods normally
+          // report device-reported errors.
+          return { success: false, details: "device unreachable" };
+        },
+      },
+      logger: createLogger(),
+    };
+
+    const started = await metaModule.invoke("start_background_task", {
+      name: "resolved-failure",
+      operation: "read",
+      intervalMs: 5,
+      maxIterations: 1,
+    }, ctx);
+    assert.equal(started.metadata?.success, true);
+
+    const task = await waitForTaskCompletion(metaModule, "resolved-failure", ctx);
+    assert.equal(task?.status, "error");
+    assert.ok(String(task?.lastError ?? "").includes("device unreachable"));
+  } finally {
+    if (previous === undefined) delete process.env.C64_TASK_STATE_FILE;
+    else process.env.C64_TASK_STATE_FILE = previous;
+  }
+});
+
 test("background tasks stop active timers and support write_memory alias defaults", async () => {
   const { file, dir } = tmpPath("background5", "tasks.json");
   await fs.mkdir(dir, { recursive: true });

--- a/test/meta/backgroundState.test.mjs
+++ b/test/meta/backgroundState.test.mjs
@@ -97,7 +97,7 @@ describe("meta/background state loading", () => {
     expect(stored).toEqual({ tasks: [] });
   });
 
-  test("start_background_task rejects a duplicate running task loaded from disk", async () => {
+  test("HARD01-022 a task persisted as 'running' is downgraded to 'stopped' on reload, not left as a zombie", async () => {
     const { file, dir } = tmpPath("background-duplicate", "tasks.json");
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(file, JSON.stringify({
@@ -115,7 +115,7 @@ describe("meta/background state loading", () => {
           updatedAt: "2025-03-08T10:00:05.000Z",
           stoppedAt: null,
           lastError: null,
-          nextRunAt: null,
+          nextRunAt: "2025-03-08T10:00:20.000Z",
           folder: path.join("tasks", "background", "0012_dup"),
         },
       ],
@@ -123,16 +123,28 @@ describe("meta/background state loading", () => {
 
     process.env.C64_TASK_STATE_FILE = file;
     const { tools } = await loadBackgroundTools("duplicate");
+    const listTool = toolByName(tools, "list_background_tasks");
     const startTool = toolByName(tools, "start_background_task");
+    const stopTool = toolByName(tools, "stop_background_task");
 
+    // The persisted "running" status must not survive reload: no timer exists
+    // for it, so reporting it as running would be a false health signal.
+    const listed = await listTool.execute({}, { client: {}, logger: createLogger() });
+    const reloaded = listed.structuredContent?.data?.tasks?.find((t) => t.name === "dup");
+    expect(reloaded?.status).toBe("stopped");
+    expect(reloaded?.nextRunAt).toBeFalsy();
+    expect(String(reloaded?.lastError ?? "")).toContain("restart");
+
+    // Because the reloaded task is honestly "stopped", starting a new task
+    // under the same name must now succeed rather than be rejected.
     const result = await startTool.execute(
       { name: "dup", operation: "read", intervalMs: 5, maxIterations: 1 },
       { client: {}, logger: createLogger() },
     );
+    expect(result.isError).toBeUndefined();
+    expect(result.metadata?.success).toBe(true);
 
-    expect(result.isError).toBe(true);
-    expect(result.metadata?.error?.kind).toBe("validation");
-    expect(String(result.metadata?.error?.message ?? result.content?.[0]?.text ?? "")).toContain("already running");
+    await stopTool.execute({ name: "dup" }, { client: {}, logger: createLogger() });
   });
 
   test("start_background_task supports read_memory alias with default arguments", async () => {

--- a/test/platformRegistry.test.mjs
+++ b/test/platformRegistry.test.mjs
@@ -45,6 +45,39 @@ function createCtx(client, setPlatformCalls, platform = "c64u") {
   };
 }
 
+test("HARD01-030 c64_select_backend cancels an in-flight music_generate arpeggio", async () => {
+  const noteOnCalls = [];
+  const setPlatformCalls = [];
+  const client = createSwitchClient(["c64u", "vice"], "vice");
+  client.pinFacade = async () => ({ type: "vice" });
+  client.sidSetVolume = async () => ({ success: true });
+  client.sidNoteOn = async (payload) => { noteOnCalls.push(payload.note); return { success: true }; };
+  client.sidNoteOff = async () => ({ success: true });
+
+  const scheduleResult = await toolRegistry.invoke(
+    "c64_sound",
+    { op: "generate", root: "C4", pattern: "0,4,7,12,16", steps: 5, tempoMs: 40 },
+    createCtx(client, setPlatformCalls, "vice"),
+  );
+  assert.equal(scheduleResult.isError, undefined);
+
+  // Let one or two notes play, then switch backends mid-arpeggio.
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  const callsBeforeSwitch = noteOnCalls.length;
+  assert.ok(callsBeforeSwitch >= 1, "expected at least one note before the switch");
+
+  await toolRegistry.invoke(
+    "c64_select_backend",
+    { op: "select", backend: "c64u" },
+    createCtx(client, setPlatformCalls, "vice"),
+  );
+
+  // Wait past the arpeggio's full natural duration; cancellation must have
+  // stopped further notes rather than letting them keep playing.
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  assert.equal(noteOnCalls.length, callsBeforeSwitch);
+});
+
 test("c64_select_backend switches to an available backend and updates platform state", async () => {
   const client = createSwitchClient(["c64u", "vice"], "c64u");
   const setPlatformCalls = [];

--- a/test/pollIntegration.test.mjs
+++ b/test/pollIntegration.test.mjs
@@ -157,29 +157,38 @@ test("ASM polling respects environment variables", async () => {
   }
 });
 
-test("ASM program that executes instantly without RUN showing is ok", async () => {
+test("HARD01-036 ASM program with no RUN echo is ok only when screen RAM genuinely progresses", async () => {
+  // Previously this asserted a blind "ok" whenever RUN never appeared, which
+  // is exactly the false-success the HARD01-036 fix removes: a firmware that
+  // reports success but never runs the program produces no RUN echo either.
+  // The truthful scenario this now covers is a native run_prg path that never
+  // echoes RUN yet demonstrably progresses screen RAM, which the liveness
+  // check must observe before it may report success.
   const restoreStabilize = withPollStabilize(0);
+  let memoryCallCount = 0;
   const ctx = {
     client: {
       async uploadAndRunAsm(program) {
         return { success: true };
       },
       async readScreen() {
-        // Program executed so fast RUN never showed
-        return "READY.\n";
+        return "READY.\n"; // RUN text never appears on this execution path.
+      },
+      async readMemoryRaw(_address, length) {
+        memoryCallCount++;
+        return new Uint8Array(length).fill(memoryCallCount <= 1 ? 0 : 1); // Real, observable progression.
       },
     },
     logger: createLogger(),
   };
-  
+
   try {
     const result = await programRunnersModule.invoke(
       "upload_run_asm",
-      { program: ".org $0801\nrts" }, // Instant return
+      { program: ".org $0801\nrts" },
       ctx,
     );
-    
-    // Should be considered ok (instant execution)
+
     assert.equal(result.isError, undefined);
   } finally {
     restoreStabilize();

--- a/test/pollValidator.test.mjs
+++ b/test/pollValidator.test.mjs
@@ -313,38 +313,73 @@ test("pollForProgramOutcome handles screen read failures gracefully", async () =
   assert.equal(result.type, "BASIC");
 });
 
-test("pollForProgramOutcome BASIC returns ok if RUN not detected", async () => {
+test("HARD01-036 pollForProgramOutcome BASIC reports an error instead of blind success when RUN is never detected", async () => {
+  // Regression test for a real hardware finding: a firmware run_prg call can
+  // report success (HARD01-011: empty errors[]) while silently never
+  // executing the uploaded program. The screen never advances past its
+  // pre-run state in that case, so "RUN"/"ERROR" text never appears.
   const client = {
     async readScreen() {
       return "READY.\n";
     },
   };
-  
+
   const result = await pollForProgramOutcome(
     "BASIC",
     client,
     createLogger(),
     { maxMs: 50, intervalMs: 10, stabilizeMs: 0 },
   );
-  
-  assert.equal(result.status, "ok");
+
+  assert.equal(result.status, "error");
   assert.equal(result.type, "BASIC");
+  assert.match(result.message, /does not appear to have run/i);
 });
 
-test("pollForProgramOutcome ASM returns ok if RUN not detected", async () => {
+test("HARD01-036 pollForProgramOutcome ASM reports crashed instead of blind success when RUN is never detected", async () => {
+  // Regression test mirroring the BASIC case above: previously, never
+  // observing RUN/ERROR text short-circuited straight to a false "ok"
+  // without ever running the hardware liveness check.
   const client = {
     async readScreen() {
       return "READY.\n";
     },
   };
-  
+
   const result = await pollForProgramOutcome(
     "ASM",
     client,
     createLogger(),
     { maxMs: 50, intervalMs: 10, stabilizeMs: 0 },
   );
-  
+
+  assert.equal(result.status, "crashed");
+  assert.equal(result.type, "ASM");
+  assert.equal(result.reason, "no program-visible screen progression within window");
+});
+
+test("HARD01-036 pollForProgramOutcome ASM still detects real liveness even when RUN text never appears", async () => {
+  // The corresponding positive case: if RUN/ERROR text never shows up but
+  // screen RAM genuinely changes (e.g. a firmware-native run that doesn't
+  // echo anything to the screen), the liveness check must still catch it.
+  let memoryCallCount = 0;
+  const client = {
+    async readScreen() {
+      return "READY.\n";
+    },
+    async readMemoryRaw(_address, length) {
+      memoryCallCount++;
+      return new Uint8Array(length).fill(memoryCallCount <= 1 ? 0 : 1);
+    },
+  };
+
+  const result = await pollForProgramOutcome(
+    "ASM",
+    client,
+    createLogger(),
+    { maxMs: 100, intervalMs: 10, stabilizeMs: 0 },
+  );
+
   assert.equal(result.status, "ok");
   assert.equal(result.type, "ASM");
 });

--- a/test/pollValidator.test.mjs
+++ b/test/pollValidator.test.mjs
@@ -245,7 +245,47 @@ test("pollForProgramOutcome ASM detects crash when no screen change", async () =
   
   assert.equal(result.status, "crashed");
   assert.equal(result.type, "ASM");
-  assert.equal(result.reason, "no VIC/CIA/TI/screen progression within window");
+  assert.equal(result.reason, "no program-visible screen progression within window");
+});
+
+test("HARD01-019/HARD01-020 ASM polling only ever reads screen RAM, never VIC/CIA I/O, and a stable signature is reported crashed", async () => {
+  const memoryReads = [];
+  const client = {
+    async readScreen() {
+      return "RUN\nSYS 2061\n";
+    },
+    async readMemoryRaw(address, length) {
+      memoryReads.push({ address, length });
+      // A perfectly stable buffer: if the poller were still reading
+      // free-running VIC/CIA registers, a real machine would never produce
+      // this, so "crashed" here proves the signature is screen-only.
+      return new Uint8Array(length);
+    },
+  };
+
+  const result = await pollForProgramOutcome(
+    "ASM",
+    client,
+    createLogger(),
+    { maxMs: 80, intervalMs: 10, stabilizeMs: 0 },
+  );
+
+  assert.equal(result.status, "crashed");
+  assert.equal(result.type, "ASM");
+  assert.ok(memoryReads.length > 0, "expected at least one poll read");
+
+  // No poll may ever have touched the I/O page (VIC/SID/CIA1/CIA2), and in
+  // particular never the CIA interrupt-control registers, whose reads have
+  // hardware side effects (they acknowledge pending IRQs on real hardware).
+  const CIA1_ICR = 0xDC0D;
+  const CIA2_ICR = 0xDD0D;
+  for (const read of memoryReads) {
+    const end = read.address + read.length - 1;
+    const overlapsIo = read.address <= 0xDFFF && end >= 0xD000;
+    assert.equal(overlapsIo, false, `poll must not read the I/O page: ${JSON.stringify(read)}`);
+    assert.ok(!(read.address <= CIA1_ICR && end >= CIA1_ICR));
+    assert.ok(!(read.address <= CIA2_ICR && end >= CIA2_ICR));
+  }
 });
 
 test("pollForProgramOutcome handles screen read failures gracefully", async () => {
@@ -384,11 +424,37 @@ test("loadPollConfig uses production defaults outside test mode", () => {
   else process.env.NODE_ENV = previousEnv;
 });
 
-test("pollForProgramOutcome BASIC falls back to UNKNOWN ERROR when only ERROR is visible", async () => {
+test("HARD01-021 pollForProgramOutcome BASIC treats '0 ERRORS FOUND' output as success, not a false failure", async () => {
   const screens = [
     "READY.\n",
     "RUN\n",
-    "ERROR\nREADY.\n",
+    "0 ERRORS FOUND\nREADY.\n",
+  ];
+
+  const client = {
+    async readScreen() {
+      const screen = screens.shift();
+      if (!screen) return "0 ERRORS FOUND\nREADY.\n";
+      return screen;
+    },
+  };
+
+  const result = await pollForProgramOutcome(
+    "BASIC",
+    client,
+    createLogger(),
+    { maxMs: 200, intervalMs: 20, stabilizeMs: 0 },
+  );
+
+  assert.equal(result.status, "ok");
+  assert.equal(result.type, "BASIC");
+});
+
+test("HARD01-021 pollForProgramOutcome BASIC detects a canonical '?SYNTAX ERROR IN 20' as a real failure", async () => {
+  const screens = [
+    "READY.\n",
+    "RUN\n",
+    "?SYNTAX  ERROR IN 20\nREADY.\n",
   ];
 
   const client = {
@@ -408,8 +474,8 @@ test("pollForProgramOutcome BASIC falls back to UNKNOWN ERROR when only ERROR is
 
   assert.equal(result.status, "error");
   assert.equal(result.type, "BASIC");
-  assert.equal(result.message, "UNKNOWN ERROR");
-  assert.equal(result.line, undefined);
+  assert.equal(result.message, "SYNTAX");
+  assert.equal(result.line, 20);
 });
 
 test("pollForProgramOutcome ASM tolerates screen read failures before RUN and then detects activity", async () => {
@@ -459,7 +525,7 @@ test("pollForProgramOutcome ASM treats repeated memory read failures as crashed"
 
   assert.equal(result.status, "crashed");
   assert.equal(result.type, "ASM");
-  assert.equal(result.reason, "no VIC/CIA/TI/screen progression within window");
+  assert.equal(result.reason, "no program-visible screen progression within window");
 });
 
 test("pollForProgramOutcome ASM treats jiffy clock progress as activity even when other signatures stay stable", async () => {

--- a/test/programRunnersModule.test.mjs
+++ b/test/programRunnersModule.test.mjs
@@ -906,7 +906,7 @@ test("upload_run_asm verify true annotates metadata", async () => {
 
   try {
     let screenCall = 0;
-    let lowMemCall = 0;
+    let screenRamCall = 0;
     const ctx = {
       client: {
         async uploadAndRunAsm() {
@@ -917,13 +917,10 @@ test("upload_run_asm verify true annotates metadata", async () => {
           return screenCall === 1 ? "RUN\n" : "READY.\n";
         },
         async readMemoryRaw(address, length) {
-          if (address === 0xD000) {
-            return new Uint8Array(length);
-          }
-          if (address === 0x0000) {
+          if (address === 0x0400) {
             const buffer = new Uint8Array(length);
-            buffer[0xA0] = lowMemCall & 0xff;
-            lowMemCall += 1;
+            buffer[0] = screenRamCall & 0xff;
+            screenRamCall += 1;
             return buffer;
           }
           throw new Error(`unexpected address ${address}`);
@@ -978,7 +975,7 @@ test("upload_run_asm reports crashed programs when verification detects no progr
           return "RUN\n";
         },
         async readMemoryRaw(address, length) {
-          if (address === 0xD000 || address === 0x0000) {
+          if (address === 0x0400) {
             return new Uint8Array(length);
           }
           throw new Error(`unexpected address ${address}`);
@@ -995,7 +992,7 @@ test("upload_run_asm reports crashed programs when verification detects no progr
 
     assert.equal(result.isError, true);
     assert.equal(result.metadata.error.kind, "execution");
-    assert.equal(result.metadata.error.details.reason, "no VIC/CIA/TI/screen progression within window");
+    assert.equal(result.metadata.error.details.reason, "no program-visible screen progression within window");
   } finally {
     if (originalMax === undefined) delete process.env.C64BRIDGE_POLL_MAX_MS;
     else process.env.C64BRIDGE_POLL_MAX_MS = originalMax;

--- a/test/programRunnersModule.test.mjs
+++ b/test/programRunnersModule.test.mjs
@@ -553,7 +553,10 @@ test("upload_run_basic verify true annotates metadata", async () => {
         },
         async readScreen() {
           screenReads += 1;
-          return "READY.\n";
+          // First read is the immediate post-run screen check in
+          // executeUploadRunBasic; the poll loop's first read then observes
+          // the firmware's own RUN echo, matching real backend behavior.
+          return screenReads === 1 ? "READY.\n" : "RUN\n";
         },
       },
       logger: createLogger(),
@@ -633,13 +636,21 @@ test("upload_run_basic verify tolerates repeated screen read failures", async ()
   process.env.C64BRIDGE_POLL_INTERVAL_MS = "1";
 
   try {
+    let readCalls = 0;
     const ctx = {
       client: {
         async uploadAndRunBasic() {
           return { success: true };
         },
         async readScreen() {
-          throw new Error("screen transport offline");
+          readCalls += 1;
+          // Transient failures (e.g. a momentary transport hiccup) must not
+          // be mistaken for "nothing executed" — the poller should keep
+          // retrying and still observe RUN once reads start succeeding.
+          if (readCalls <= 3) {
+            throw new Error("screen transport offline");
+          }
+          return "RUN\n";
         },
       },
       logger: createLogger(),
@@ -870,11 +881,19 @@ test("upload_run_asm handles firmware failure", async () => {
 
 test("upload_run_asm returns structured content on success", async () => {
   const calls = [];
+  let screenRamCall = 0;
   const ctx = {
     client: {
       async uploadAndRunAsm(program) {
         calls.push(program);
         return { success: true, details: { ok: true } };
+      },
+      async readScreen() {
+        return "RUN\n";
+      },
+      async readMemoryRaw(_address, length) {
+        screenRamCall += 1;
+        return new Uint8Array(length).fill(screenRamCall <= 1 ? 0 : 1);
       },
     },
     logger: createLogger(),
@@ -1001,20 +1020,33 @@ test("upload_run_asm reports crashed programs when verification detects no progr
   }
 });
 
-test("upload_run_asm verify treats repeated screen read failures as instant execution", async () => {
+test("upload_run_asm verify tolerates transient screen read failures and still verifies via liveness", async () => {
   const originalMax = process.env.C64BRIDGE_POLL_MAX_MS;
   const originalInterval = process.env.C64BRIDGE_POLL_INTERVAL_MS;
-  process.env.C64BRIDGE_POLL_MAX_MS = "20";
+  process.env.C64BRIDGE_POLL_MAX_MS = "60";
   process.env.C64BRIDGE_POLL_INTERVAL_MS = "1";
 
   try {
+    let readScreenCalls = 0;
+    let screenRamCall = 0;
     const ctx = {
       client: {
         async uploadAndRunAsm() {
           return { success: true };
         },
         async readScreen() {
-          throw new Error("monitor unavailable");
+          readScreenCalls += 1;
+          // A momentary monitor hiccup must not be mistaken for "nothing
+          // executed" — the poller should keep retrying and still confirm
+          // real liveness once reads start succeeding.
+          if (readScreenCalls <= 3) {
+            throw new Error("monitor unavailable");
+          }
+          return "RUN\n";
+        },
+        async readMemoryRaw(_address, length) {
+          screenRamCall += 1;
+          return new Uint8Array(length).fill(screenRamCall <= 1 ? 0 : 1);
         },
       },
       logger: createLogger(),

--- a/test/ragForeignCwd.test.mjs
+++ b/test/ragForeignCwd.test.mjs
@@ -1,0 +1,99 @@
+import test from "#test/runner";
+import assert from "#test/assert";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const tsLoader = "tsx/esm";
+
+function resolveNodeExecutable() {
+  const candidates = [
+    process.env.C64BRIDGE_TEST_NODE_BIN,
+    process.env.C64BRIDGE_NODE_BIN,
+    process.env.NODE_BINARY,
+    process.env.NODE_EXEC_PATH,
+    process.env.npm_node_execpath,
+  ];
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) return candidate.trim();
+  }
+  // process.execPath can be the Bun binary when this file runs under `bun
+  // test`; Bun's --eval/--import flag handling differs from Node's, so a
+  // real `node` binary is required for this child regardless of runner.
+  return "node";
+}
+
+test("HARD01-025 initRag loads the bundled indexes from the package directory even when the process cwd is a foreign (installed-package-style) working directory", async (t) => {
+  const foreignCwd = fs.mkdtempSync(path.join(os.tmpdir(), "c64bridge-foreign-cwd-"));
+  t.after(() => fs.rmSync(foreignCwd, { recursive: true, force: true }));
+
+  const scriptPath = path.join(os.tmpdir(), `c64bridge-rag-foreign-cwd-probe-${process.pid}-${Date.now()}.mjs`);
+  const resultPath = path.join(os.tmpdir(), `c64bridge-rag-foreign-cwd-result-${process.pid}-${Date.now()}.json`);
+  t.after(() => {
+    fs.rmSync(scriptPath, { force: true });
+    fs.rmSync(resultPath, { force: true });
+  });
+  fs.writeFileSync(
+    scriptPath,
+    `
+    // Simulate the documented npm-installed layout: the server module lives
+    // under the caller's node_modules, but the caller's own project (an
+    // unrelated cwd) is what's actually running. process.chdir happens
+    // before any RAG module import, so module-level path resolution must
+    // not have baked in the launch cwd.
+    process.chdir(${JSON.stringify(foreignCwd)});
+    const { initRag } = await import(${JSON.stringify(path.join(repoRoot, "src", "rag", "init.ts"))});
+    const retriever = await initRag();
+    const results = await retriever.retrieve("PRINT statement", 3, "basic");
+    // Write to a dedicated result file rather than stdout: debug logging
+    // (console.debug) also writes to stdout and would otherwise corrupt it.
+    const fs2 = await import("node:fs");
+    fs2.writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ count: results.length, cwd: process.cwd() }));
+    `,
+    "utf8",
+  );
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  // The test harness itself points RAG_EMBEDDINGS_DIR at a small fixture
+  // directory for speed/determinism (see scripts/run-tests.ts). This test's
+  // whole point is the package-relative default resolution, so that
+  // override must not leak into the child.
+  const childEnv = { ...process.env };
+  delete childEnv.RAG_EMBEDDINGS_DIR;
+  delete childEnv.C64BRIDGE_ASSET_ROOT;
+
+  const exitCode = await new Promise((resolve, reject) => {
+    const child = spawn(
+      resolveNodeExecutable(),
+      ["--import", tsLoader, scriptPath],
+      {
+        cwd: repoRoot,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+    child.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`RAG foreign-cwd child probe failed with exit code ${exitCode}\n${stderrChunks.join("")}`);
+  }
+
+  const output = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+  assert.equal(output.cwd, fs.realpathSync(foreignCwd));
+  // The bundled BASIC index must have resolved and returned real snippets
+  // despite the foreign cwd, not the empty-index silent failure HARD01-025
+  // describes.
+  assert.ok(output.count > 0, "expected at least one retrieved BASIC reference");
+});

--- a/test/sidwave.test.mjs
+++ b/test/sidwave.test.mjs
@@ -1,6 +1,6 @@
 import test from "#test/runner";
 import assert from "#test/assert";
-import { compileSidwaveToPrg, compileSidwaveToSid } from "../src/sidwaveCompiler.js";
+import { compileSidwaveToPrg, compileSidwaveToSid, hzToSidFrequency } from "../src/sidwaveCompiler.js";
 import { parseSidwave } from "../src/sidwave.js";
 import { runSidToWav, SidplayExecutionError } from "../src/sidplayRunner.js";
 import os from "node:os";
@@ -39,6 +39,14 @@ timeline:
     bars: 8
     layers: { v1: A, v2: B, v3: C }
 `;
+
+test("HARD01-032 sidwaveCompiler's hzToSidFrequency uses the SID's 24-bit phase accumulator", () => {
+  // round(440 * 2^24 / 985248) = 7493 = $1D45 (PAL A4).
+  assert.equal(hzToSidFrequency(440, "PAL"), 7493);
+  // NTSC uses a different clock (1022727 Hz) but the same 2^24 divisor.
+  assert.equal(hzToSidFrequency(440, "NTSC"), Math.round((440 * 16_777_216) / 1_022_727));
+  assert.notEqual(hzToSidFrequency(440, "PAL"), Math.round((440 * 65_536) / 985_248));
+});
 
 test("SIDWAVE: compile to PRG and SID", () => {
   const doc = parseSidwave(EXAMPLE);

--- a/test/suites/mcpServerCallToolSuite.mjs
+++ b/test/suites/mcpServerCallToolSuite.mjs
@@ -202,7 +202,7 @@ export function registerMcpServerCallToolTests(withSharedMcpClient) {
     await withSharedMcpClient(async (ctx) => {
       const { mockServer } = ctx;
       const program = `\n      .org $0801\nstart:\n      lda #$01\n      sta $0400\n      rts\n    `;
-      const runCountBefore = mockServer.state.runCount;
+      const loadCountBefore = mockServer.state.loadCount;
 
       const { result, supported } = await callTool(ctx, "c64_program", {
         op: "upload_run_asm",
@@ -219,16 +219,18 @@ export function registerMcpServerCallToolTests(withSharedMcpClient) {
       assert.match(textContent.text, /Assembly program assembled/i);
 
       assert.ok(result.metadata?.success, "metadata should flag success");
-      assert.equal(result.metadata?.details?.result ?? "ok", "ok");
       if (ctx.platform === "vice") {
-        assert.equal(mockServer.state.runCount, runCountBefore, "vice mode must not assemble-run via the C64U mock");
+        assert.equal(mockServer.state.loadCount, loadCountBefore, "vice mode must not load via the C64U mock");
         assert.equal(result.structuredContent?.data?.kind, "upload_run_asm");
         assert.equal(result.structuredContent?.data?.format, "prg");
         return;
       }
 
-      assert.equal(mockServer.state.runCount, runCountBefore + 1, "mock server should execute program once");
-      assert.ok(mockServer.state.lastPrg, "mock server should receive PRG payload");
+      // HARD01-018: assembled machine code is loaded (not LOAD+RUN) and
+      // entered via a typed SYS to its own entry point.
+      assert.equal(mockServer.state.loadCount, loadCountBefore + 1, "mock server should load the assembled program once");
+      assert.ok(mockServer.state.lastLoadedPrg, "mock server should receive the loaded PRG payload");
+      assert.equal(mockServer.state.memory[0x0801], 0xa9, "assembled LDA opcode should land at its own address");
     });
   });
 

--- a/test/toolsCoverage.test.mjs
+++ b/test/toolsCoverage.test.mjs
@@ -7,11 +7,13 @@ process.env.C64_TEST_TARGET = "stub";
 
 const writes = [];
 let lastPrg = null;
+let lastLoadedPrg = null;
 
 const stubFacade = {
   type: "c64u",
   async ping() { return true; },
   async runPrg(prg) { lastPrg = prg; return { success: true, details: { prgLength: prg?.length ?? 0 } }; },
+  async loadPrg(prg) { lastLoadedPrg = prg; return { success: true, details: { prgLength: prg?.length ?? 0 } }; },
   async loadPrgFile() { return { success: true }; },
   async runPrgFile() { return { success: true }; },
   async runCrtFile() { return { success: true }; },
@@ -82,6 +84,14 @@ test("C64Client MCP tool coverage", async (t) => {
 
     const asm = await client.uploadAndRunAsm("*=$0801\nBRK");
     expectSuccess(asm, "upload_run_asm");
+    // HARD01-018: the assembled code must be loaded (not LOAD+RUN, which
+    // would misinterpret the opcodes as BASIC text) and entered via a typed
+    // SYS to the entry point rather than a bare RUN.
+    assert.ok(lastLoadedPrg instanceof Uint8Array, "PRG bytes loaded without running");
+    assert.equal(asm.details.entryAddress, 0x0801);
+    const sysBytes = writes.find((w) => w.address === 0x0277)?.bytes;
+    assert.ok(sysBytes, "SYS command written to the KERNAL keyboard buffer");
+    assert.equal(Buffer.from(sysBytes).toString("ascii"), "SYS2049\r");
 
     expectSuccess(await client.loadPrgFile("//disk/demo.prg"), "load_prg");
     expectSuccess(await client.runPrgFile("//disk/demo.prg"), "run_prg");

--- a/test/viceClient.test.mjs
+++ b/test/viceClient.test.mjs
@@ -148,6 +148,94 @@ test("ViceClient encodes requests and decodes protocol responses", async (t) => 
   assert.equal(requests[7].body.subarray(1).toString("ascii"), "RUN\r");
 });
 
+test("HARD01-014 joyportSet sends BM command 0xA2 with port and active-low value encoded per spec", async (t) => {
+  const requests = [];
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 11) {
+        const bodyLen = buffer.readUInt32LE(2);
+        const total = 11 + bodyLen;
+        if (buffer.length < total) return;
+        const packet = buffer.subarray(0, total);
+        buffer = buffer.subarray(total);
+        const request = parseRequest(packet);
+        requests.push(request);
+        socket.write(buildResponse(request.reqId, request.cmd, Buffer.alloc(0)));
+      }
+    });
+  });
+  t.after(async () => { await closeServer(server); });
+
+  const port = await listen(server);
+  const client = new ViceClient();
+  t.after(() => client.close());
+  await client.connect(port);
+
+  await client.joyportSet(2, 0xF7); // port 2, right pressed (active-low bit cleared)
+  await client.joyportSet(1, 0xFF); // port 1, released
+
+  assert.deepEqual(requests.map((r) => r.cmd), [0xA2, 0xA2]);
+  assert.equal(requests[0].body.readUInt16LE(0), 2);
+  assert.equal(requests[0].body.readUInt16LE(2), 0xF7);
+  assert.equal(requests[1].body.readUInt16LE(0), 1);
+  assert.equal(requests[1].body.readUInt16LE(2), 0xFF);
+});
+
+test("HARD01-012 a request that never gets a response times out, releases the pending queue, and a later request succeeds after reconnect", async (t) => {
+  let respond = false;
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 11) {
+        const bodyLen = buffer.readUInt32LE(2);
+        const total = 11 + bodyLen;
+        if (buffer.length < total) return;
+        const packet = buffer.subarray(0, total);
+        buffer = buffer.subarray(total);
+        if (!respond) {
+          // Simulate a lost/never-answered frame: accept the command, never reply.
+          continue;
+        }
+        const request = parseRequest(packet);
+        socket.write(buildResponse(request.reqId, request.cmd, Buffer.alloc(0)));
+      }
+    });
+  });
+
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  const port = await listen(server);
+  const client = new ViceClient();
+  t.after(() => client.close());
+  await client.connect(port);
+
+  const start = Date.now();
+  await assert.rejects(
+    // Bypass the public wrappers' long production default so the test stays
+    // fast and deterministic; `send` is TS-private only, not runtime-hidden.
+    () => client.send(0x85, undefined, { timeoutMs: 100 }),
+    /timed out/,
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed >= 90, `expected the request to wait roughly the timeout, got ${elapsed}ms`);
+  assert.equal(client.pending.size, 0, "the timed-out request must be removed from the pending map");
+
+  // The timeout destroys the unhealthy socket. Production always constructs
+  // a fresh ViceClient per connection (see ViceBackend.withClient); match
+  // that here rather than reusing the client whose old socket's async
+  // teardown could otherwise race a new pending request.
+  respond = true;
+  const reconnected = new ViceClient();
+  t.after(() => reconnected.close());
+  await reconnected.connect(port);
+  await reconnected.info();
+});
+
 test("ViceClient re-syncs partial frames and ignores unsolicited events", () => {
   const client = new ViceClient();
   let resolvedFrame = null;

--- a/test/viceClient.test.mjs
+++ b/test/viceClient.test.mjs
@@ -349,3 +349,45 @@ test("ViceClient rejects pending requests on socket errors and close is defensiv
     closingClient.close();
   });
 });
+
+test("ViceClient skips the reserved 0xFFFFFFFF reqId on wraparound instead of colliding with unsolicited events", async (t) => {
+  const requests = [];
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      while (buffer.length >= 11) {
+        const bodyLen = buffer.readUInt32LE(2);
+        const total = 11 + bodyLen;
+        if (buffer.length < total) return;
+        const packet = buffer.subarray(0, total);
+        buffer = buffer.subarray(total);
+        const request = parseRequest(packet);
+        requests.push(request);
+        socket.write(buildResponse(request.reqId, request.cmd));
+      }
+    });
+  });
+
+  t.after(async () => {
+    await closeServer(server);
+  });
+
+  const port = await listen(server);
+  const client = new ViceClient();
+  t.after(() => {
+    client.close();
+  });
+
+  await client.connect(port);
+  client.nextReqId = 0xffffffff;
+
+  await client.resetSoft();
+  await client.resetHard();
+
+  assert.equal(requests.length, 2);
+  // The first request must not be issued with the reserved unsolicited-event
+  // marker; it wraps to 0 instead, and the following request picks up at 1.
+  assert.equal(requests[0].reqId, 0x00000000);
+  assert.equal(requests[1].reqId, 0x00000001);
+});

--- a/test/viceIntegration.test.mjs
+++ b/test/viceIntegration.test.mjs
@@ -202,6 +202,48 @@ test("ViceClient integrates with the VICE mock server for debugger and resource 
   assert.equal(checkpoints.length, 0);
 });
 
+test("HARD01-015 checkpointCreate honours explicit operation flags exactly, without silently adding execute", async (t) => {
+  const session = await createViceSession();
+  t.after(async () => {
+    await session.close();
+  });
+
+  // A store-only watchpoint must not also trap on execute.
+  const storeOnly = await session.client.checkpointCreate({
+    start: 0x1000,
+    end: 0x1000,
+    operations: { store: true },
+  });
+  assert.equal(storeOnly.operations.store, true);
+  assert.equal(storeOnly.operations.load, false);
+  assert.equal(storeOnly.operations.execute, false);
+
+  // A load-only watchpoint likewise must not trap on execute.
+  const loadOnly = await session.client.checkpointCreate({
+    start: 0x1100,
+    end: 0x1100,
+    operations: { load: true },
+  });
+  assert.equal(loadOnly.operations.load, true);
+  assert.equal(loadOnly.operations.execute, false);
+
+  // No operations object at all still defaults to a plain execute breakpoint.
+  const defaulted = await session.client.checkpointCreate({ start: 0x1200, end: 0x1200 });
+  assert.equal(defaulted.operations.execute, true);
+  assert.equal(defaulted.operations.load, false);
+  assert.equal(defaulted.operations.store, false);
+
+  // An explicit combination is honoured exactly, including execute:false.
+  const explicit = await session.client.checkpointCreate({
+    start: 0x1300,
+    end: 0x1300,
+    operations: { load: true, store: true, execute: false },
+  });
+  assert.equal(explicit.operations.load, true);
+  assert.equal(explicit.operations.store, true);
+  assert.equal(explicit.operations.execute, false);
+});
+
 test("ViceClient validates error cases against the VICE mock server", async (t) => {
   const session = await createViceSession();
   t.after(async () => {
@@ -629,6 +671,45 @@ test("startViceProcess starts and stops a monitor process without Xvfb", async (
     await waitForPort(handle.host, handle.port, 500);
     await handle.stop();
     assert.ok(handle.process.signalCode !== null || handle.process.exitCode !== null);
+  } finally {
+    if (previousDisplay === undefined) {
+      delete process.env.DISPLAY;
+    } else {
+      process.env.DISPLAY = previousDisplay;
+    }
+  }
+});
+
+test("HARD01-013 stopSync synchronously terminates the managed VICE process, for use from a process 'exit' handler", async (t) => {
+  const fakeVice = createFakeViceBinary(t, "listen");
+  const previousDisplay = process.env.DISPLAY;
+  process.env.DISPLAY = ":1";
+
+  try {
+    const handle = await startViceProcess({
+      binary: fakeVice,
+      host: "127.0.0.1",
+      port: 6521,
+      visible: true,
+      warp: false,
+    });
+    t.after(async () => {
+      await handle.stop().catch(() => {});
+    });
+
+    await waitForPort(handle.host, handle.port, 500);
+    assert.equal(handle.process.exitCode, null);
+    assert.equal(handle.process.signalCode, null);
+
+    // stopSync must be safe to call from a synchronous 'exit' handler: no
+    // awaited work, just an immediate best-effort kill.
+    handle.stopSync();
+
+    await waitForExit(handle.process, 2_000);
+    assert.ok(handle.process.signalCode !== null || handle.process.exitCode !== null);
+
+    // Calling it again on an already-exited child must not throw.
+    assert.doesNotThrow(() => handle.stopSync());
   } finally {
     if (previousDisplay === undefined) {
       delete process.env.DISPLAY;


### PR DESCRIPTION
## Summary

Implements every confirmed finding (**HARD01-001 through HARD01-035**) from the whole-server hardening review at [`doc/reviews/hardening/01-fable/review.md`](doc/reviews/hardening/01-fable/review.md), commissioned to find false-success, wrong-target, lifecycle, input, filesystem, SID, and packaging failures across the MCP server, Ultimate REST backend, VICE backend, and background tooling.

The public MCP contract is preserved **except** where an existing tool result was demonstrably false (e.g. `power_cycle` claiming success without verifying the highlighted menu item, `upload_run_asm` claiming execution when the code never ran). In those cases the tool now returns a clear, actionable failure instead.

## What changed, by theme

### Ultimate REST truthfulness
- **HARD01-011**: Any C64U/U2 REST response with a non-empty firmware `errors[]` is now treated as failure, even on HTTP 200 — previously every `run_prg`/`mount`/`config`/etc. call reported success purely because the HTTP call didn't throw.
- **HARD01-002 / HARD01-003**: `power_cycle` now verifies the *highlighted* Tool Menu row via the colour matrix before sending the final RETURN, aborts if it can't confirm the selection, and attempts a best-effort menu close on any mid-flow failure.
- **HARD01-010**: Device filesystem paths are encoded per path segment so nested `/` separators stay literal instead of being double-encoded as `%2F`.
- **HARD01-023**: `drivesList()` is normalized to one `{id, power, image, type}` shape on both the c64u and VICE facades, so `drive_mount_and_verify` actually works against real firmware's `{errors, drives: [{id: info}]}` response.
- **HARD01-024**: `X-Password` (and other credential-shaped headers) are redacted case-insensitively before reaching debug logs/diagnostics.

### VICE lifecycle and transport
- **HARD01-012**: Binary Monitor requests now carry a per-request timeout that rejects, clears the pending-request map, and destroys the socket — one lost frame no longer wedges every later VICE operation forever.
- **HARD01-013**: SIGINT/SIGTERM/SIGHUP handlers now synchronously kill managed VICE/Xvfb processes (with a genuinely synchronous path usable from a process `exit` hook), so sessions don't leak orphaned processes.
- **HARD01-014**: VICE joystick input now uses the real Binary Monitor `0xA2` Joyport Set command instead of writing CIA data-port registers, which never actually simulated input.
- **HARD01-015**: Checkpoint operation masks honor exactly the load/store/execute flags requested instead of silently adding an execute trap.
- **HARD01-026**: VICE `reset()`/`reboot()` now returns `success:false` with readiness diagnostics when BASIC never reaches READY, instead of always reporting success.
- **HARD01-035**: VICE `configSet`/`configBatchUpdate` look up the resource's declared type before coercing, so a string resource whose value looks numeric (e.g. `"1541"`) is no longer silently turned into an integer.

### Backend-switch and config consistency
- **HARD01-016**: Multi-step flows (paused write-verify, a running SID arpeggio) now pin the facade they started on for their full lifetime via a new `pinFacade()`, so a concurrent `c64_select_backend` can no longer retarget an operation already underway.
- **HARD01-005 / HARD01-006 / HARD01-027**: One authoritative config loader with documented precedence (`C64BRIDGE_CONFIG` → cwd → home → legacy package-relative → defaults); a malformed config file now logs a redacted warning and falls back instead of crashing the server or silently disagreeing between two code paths.
- **HARD01-004**: A transient `machine:input` probe failure no longer poisons the capability cache as permanently "unknown" — it retries on the next read.
- **HARD01-025**: RAG/knowledge asset paths resolve from the installed package root, not `process.cwd()`, so an npm-installed server started from a project directory still finds its bundled data.
- **HARD01-031**: Reading `c64://platform/status` now races the live capability probe against a 750ms bound instead of blocking on a full device timeout.

### Program execution truthfulness
- **HARD01-018**: `upload_run_asm` now loads the assembled PRG (via a new `loadPrg` facade method) and enters it with a typed `SYS <entry>`, instead of LOAD+RUN — which misinterpreted raw 6510 opcodes as BASIC tokens and, for non-`$0801` origins, corrupted VICE's BASIC workspace pointers. This is the flagship fix: the documented assembly workflow now actually executes.
- **HARD01-019 / HARD01-020**: ASM liveness polling reads only screen RAM, never VIC/CIA/SID I/O — the old heuristic treated the free-running raster counter as "activity" (so it could never detect a crash) and, on real hardware, read the CIA interrupt-control registers, which acknowledges pending IRQs as a side effect.
- **HARD01-021**: BASIC error detection now requires the real `?` error prefix, so programs that print the word "ERROR" in ordinary output are no longer misreported as failed.
- **HARD01-007**: Printer text containing quotes is now spliced with `CHR$(34)`; the old doubled-quote (`""`) escaping is invalid Commodore BASIC V2 and threw a runtime `?SYNTAX ERROR`.
- **HARD01-008**: The generated PETSCII "wait for key" line actually loops until a key is pressed, instead of falling through to `READY.` immediately.
- **HARD01-009**: Keyboard queue injection now reports partial delivery via a typed timeout error instead of silently overwriting an undrained KERNAL queue.

### Background tasks, artifacts, and SID
- **HARD01-022**: Tasks persisted mid-"running" are downgraded to "stopped" with an explanatory `lastError` on reload, instead of becoming zombie entries that `list_tasks` reports as alive forever.
- **HARD01-028**: A background iteration that *resolves* `{success:false}` (rather than throwing) is now recorded as a failure.
- **HARD01-029**: `bundle_run_artifacts` validates `runId` and every derived filename, and proves containment via `path.relative` — a `runId` of `../escape` or an absolute path is rejected outright.
- **HARD01-030**: Generated SID arpeggios (`music_generate`) pin their facade at creation and are cancelled on backend switch / `sid_reset` / `sid_silence_all`, instead of an untracked detached loop that could keep writing notes to whatever backend became active later.
- **HARD01-032**: The SID frequency formula now uses the correct 24-bit phase-accumulator divisor (`hz * 2^24 / clock`) everywhere — code and knowledge docs alike. The old `2^16` formula made every generated note ~256x too low in pitch (sub-audible).
- **HARD01-033**: The envelope gate is now cleared between generated notes so ADSR actually retriggers, instead of attacking once and never articulating again.
- **HARD01-034**: Printer tools are now gated to `["c64u", "u2"]`, matching the platform-status capability that already advertised printer support on U2.

### Packaging
- **HARD01-001**: `--http [port]` now genuinely opens an HTTP MCP transport (`StreamableHTTPServerTransport`); default invocation is unchanged (stdio).

## Two regressions caught and fixed before this was ready

1. **VICE mock server didn't simulate KERNAL keyboard drain.** The HARD01-018 fix for real VICE timed out against the Binary Monitor mock (which doesn't run real 6502 code, so nothing drains the keyboard queue's pending-count byte). Added a short simulated drain to `src/vice/mockServer.ts`, matching the equivalent fix already needed for the c64u REST mock.
2. **An early HARD01-001 approach would have broken every real deployment.** A `process.argv[1] === import.meta.url` "am I the entrypoint" check seemed like a clean way to stop test imports from starting a live server — but the documented entrypoint (`src/index.ts` → `dist/index.js`, per `package.json` main/bin) always imports `mcp-server.ts` as a side effect rather than being invoked directly, so that check is always false in production and the server would never start. Replaced with an explicit `C64BRIDGE_SKIP_AUTO_START` opt-out env var, mirroring the existing `C64BRIDGE_START_SKIP_AUTO_LAUNCH` convention already used by `scripts/start.mjs`. Verified by actually running `node dist/index.js` and `node src/index.ts` end-to-end after the fix.

## Test plan

- [x] Every one of the 35 findings has a dedicated, named regression test — `grep -r "HARD01-" test/` to audit coverage.
- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [x] `npm test` (full matrix, default c64u-mock target, both Node and Bun runners) — 0 failures.
- [x] `npm run test:vice:mock` (VICE Binary Monitor mock target) — 0 failures.
- [x] `npm run build` — succeeds; `mcp/*.json` and `README.md` regenerated and diff clean against source (generator output matches checked-in files).
- [x] `npm run check:package` — passes.
- [x] `git diff --check` — no whitespace issues.
- [x] Manual smoke test: `node dist/index.js` and `node --import tsx/esm src/index.ts` both start the server correctly end-to-end (read-only connectivity probe against a live device on the test network; no state-changing calls).
- [ ] Real hardware (C64U/U64/U2) or a real VICE binary — intentionally **not** exercised, per the task's constraint against state-changing operations on real devices. All coverage is unit/mock-server based.

## Notes for reviewers

- `doc/reviews/hardening/01-fable/` (the review itself and the prompts that produced it) is included for traceability between findings and fixes; it has not been edited to hide or soften any finding.
- `mcp/*.json` and `README.md` diffs are auto-generated (`npm run build`) from the source/schema changes above — no manual edits.
